### PR TITLE
build: Add Github Action to prepare a publish

### DIFF
--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -1,0 +1,30 @@
+name: Prepare Publish
+
+on:
+  workflow_dispatch:
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Prepare Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: Install Dependencies
+        run: pnpm install
+
+      - name: Create Release Pull Request
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm run changeset:consume
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is on top of https://github.com/getsentry/spotlight/pull/21

This adds a workflow that can be triggered, which will open a PR with all the changesets consumed & versions bumped accordingly.

For now, merging this PR will not do anything. But in a follow up to this, I'll add another action that is triggered when this PR is merged into main, which will actually run the npm publish automatically.

So the flow would be, overall:

1. Include changesets in each PR
2. When we want to cut a release, trigger the `Prepare Publish` GHA workflow
3. This will create a PR that needs to be approved & merged
4. When the PR is merged, the npm publish will happen automatically