### PR TITLE
build: Publish on push to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '**/CHANGELOG.md'
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    # For whatever reason, yaml does not like the full "meta(changelog): Update package versions" string
+    # So we check this in two parts
+    if: |
+      contains(github.event.head_commit.message, 'meta(changelog)') 
+      && contains(github.event.head_commit.message, 'Update package versions')
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: Setup pnpm & install dependencies
+        uses: pnpm/action-setup@v2
+        with:
+          run_install: true
+
+      - name: Publish to NPM
+        uses: changesets/action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        with:
+          publish: pnpm changeset:publish
+          createGithubReleases: true

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "yalc:publish": "yalc publish --push --sig --private",
     "changeset:add": "pnpm changeset",
     "changeset:consume": "pnpm changeset version",
-    "changeset:publish": "pnpm changeset publish"
+    "changeset:publish": "pnpm run build && pnpm changeset publish"
   },
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.8",


### PR DESCRIPTION
This PR ensures that if the PRs generated by changeset are merged, we automatically publish to NPM.

I check this in three ways:

* Push to main only
* Push changing a `CHANGELOG.md` file
* The pushed commit has the message `meta(changelog): Update package versions` - this has to be kept in sync with the commit messages generated in the prepare-publish workflow.

Not sure if that is "bullet proof" enough, or if we need/can have more checks there 🤔 I think for now it should suffice, at least, and have very little room for misuse (worst case something that is on main is published "too early", as you can only publish off main).

I added a `NPM_TOKEN` secret to this repository.