### PR TITLE
docs: Update readmes

### DIFF
--- a/.changeset/nervous-ghosts-glow.md
+++ b/.changeset/nervous-ghosts-glow.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/core': patch
+'@spotlightjs/sidecar': patch
+---
+
+Update README

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Spotlight
+
+## Local Setup
+
+- `pnpm install`
+- `pnpm build`
+
+### Run Local Dev build
+
+If you want to locally open two terminals
+
+One is for building & watching Spotlight locally.
+
+1. `cd packages/spotlight`
+2. `pnpm dev`
+
+The other is to run the website locally:
+
+1. `cd packages/website`
+2. `pnpm dev`
+3. `open http://localhost:4321/spotlight`
+
+## Changesets
+
+Spotlight uses [Changesets](https://github.com/changesets/changesets) to track changes & versions.
+
+Whenever you make a change that is users facing, you should add a changeset to your PR. You can do this by runing the
+following command:
+
+```bash
+onpm changeset:add
+```
+
+This will guide you through the process to define the changeset. You have to select which package(s) are affected by
+this change, if it is a patch/minor/major change, and provide a description for the change.
+
+Note that not all PRs need a changeset (e.g. if you only write docs), and a PR can also have more than one changeset.
+
+## Publishing
+
+When you want to publish a new version, you need to trigger the
+[Prepare Publish](https://github.com/getsentry/spotlight/actions/workflows/prepare-publish.yml) Github Action. This
+action will open a PR with all versions bumped & changelogs updated according to the currently pending changesets. If
+you approve & merge this PR, these versions will automatically be published to NPM.

--- a/README.md
+++ b/README.md
@@ -7,25 +7,7 @@ overlay into development environments, and it does it by leveraging the existing
 
 ## Contributing / Running the repo
 
-This repo is power by `pnpm`
-
-1. `pnpm install`
-2. `pnpm build`
-
-### Run Local Dev build
-
-If you want to locally open two terminals
-
-One is for building & watching Spotlight locally.
-
-1. `cd packages/spotlight`
-2. `pnpm dev`
-
-The other is to run the website locally:
-
-1. `cd packages/website`
-2. `pnpm dev`
-3. `open http://localhost:4321/spotlight`
+See [CONTIBUTING.md](./CONTRIBUTING.md) for how to contribute and develop Spotlight.
 
 ## More on Architecture
 

--- a/packages/sidecar/README.md
+++ b/packages/sidecar/README.md
@@ -1,0 +1,18 @@
+# Spotlight Sidecar
+
+The Spotlight Sidecar is a small proxy server that allows (development) servers to send data to Spotlight.
+
+## Installation
+
+```js
+npm install @spotlightjs/sidecar
+```
+
+## Usage
+
+```js
+import { setupSidecar } from '@spotlightjs/sidecar';
+
+// When you start your dev server
+setupSidecar();
+```

--- a/packages/spotlight/README.md
+++ b/packages/spotlight/README.md
@@ -1,0 +1,20 @@
+# Spotlight Core
+
+This is the core package to add Spotlight to your application
+
+## Installation
+
+```js
+npm install @spotlightjs/core
+```
+
+## Usage
+
+```js
+import * as Spotlight from '@spotlightjs/core';
+
+Spotlight.init({
+  integrations: [Spotlight.sentry(), Spotlight.console()],
+  showTriggerButton: true,
+});
+```


### PR DESCRIPTION
* Move some stuff out from README to CONTRIBUTING
* Add dedicated READMEs for the published packages (as they show up e.g. on npmjs.com)
* Add instructions for publishing