### PR TITLE
ref(integrations): Make tabs functional to restore notification counts

### DIFF
--- a/packages/core/src/App.tsx
+++ b/packages/core/src/App.tsx
@@ -3,6 +3,7 @@ import Debugger from './components/Debugger';
 import Trigger from './components/Trigger';
 import type { Integration } from './integrations/integration';
 import { connectToSidecar } from './sidecar';
+import { TriggerButtonCount } from './types';
 
 const DEFAULT_SIDECAR = 'http://localhost:8969/stream';
 
@@ -23,6 +24,7 @@ export default function App({
 
   const [integrationData, setIntegrationData] = useState<Record<string, Array<unknown>>>({});
   const [isOnline, setOnline] = useState(false);
+  const [triggerButtonCount, setTriggerButtonCount] = useState<TriggerButtonCount>({ general: 0, severe: 0 });
 
   useEffect(() => {
     // Map that holds the information which kind of content type should be dispatched to which integration(s)
@@ -42,6 +44,7 @@ export default function App({
       contentTypeToIntegrations,
       setIntegrationData,
       setOnline,
+      setTriggerButtonCount,
     );
 
     return () => {
@@ -60,7 +63,7 @@ export default function App({
 
   return (
     <>
-      {showTriggerButton && <Trigger isOpen={isOpen} setOpen={setOpen} />}
+      {showTriggerButton && <Trigger isOpen={isOpen} setOpen={setOpen} count={triggerButtonCount} />}
       <Debugger
         isOpen={isOpen}
         setOpen={setOpen}

--- a/packages/core/src/components/Overview.tsx
+++ b/packages/core/src/components/Overview.tsx
@@ -17,7 +17,7 @@ export default function Overview({
   const tabs = integrations
     .map(integration => {
       if (integration.tabs) {
-        return integration.tabs.map(tab => ({
+        return integration.tabs({ integrationData }).map(tab => ({
           ...tab,
           active: activeTab === tab.id,
           onSelect: () => {

--- a/packages/core/src/components/Tabs.tsx
+++ b/packages/core/src/components/Tabs.tsx
@@ -40,7 +40,7 @@ export default function Tabs({ tabs, nested }: Props) {
         >
           {tabs.map((tab, tabIdx) => (
             <option key={tabIdx} value={tab.id}>
-              {tab.title}
+              {tab.title} {tab.notificationCount}
             </option>
           ))}
         </select>
@@ -61,14 +61,14 @@ export default function Tabs({ tabs, nested }: Props) {
               aria-current={tab.active ? 'page' : undefined}
             >
               {tab.title}
-              {tab.count !== undefined ? (
+              {tab.notificationCount !== undefined ? (
                 <span
                   className={classNames(
                     tab.active ? 'bg-indigo-100 text-indigo-600' : 'bg-indigo-700 text-indigo-200',
                     'ml-3 hidden rounded px-2.5 py-0.5 text-xs font-medium md:inline-block',
                   )}
                 >
-                  {tab.count}
+                  {tab.notificationCount}
                 </span>
               ) : null}
             </Link>

--- a/packages/core/src/components/Trigger.tsx
+++ b/packages/core/src/components/Trigger.tsx
@@ -1,10 +1,15 @@
-export default function Trigger({ isOpen, setOpen }: { isOpen: boolean; setOpen: (value: boolean) => void }) {
-  // TODO: replace w/ generic counter
-  // const events = []; useSentryEvents();
-  // const traces = []; useSentryTraces();
+import { TriggerButtonCount } from '~/types';
 
-  const errorCount = 0; // events.filter(e => 'exception' in e).length;
-  const traceCount = 0; //traces.length;
+export default function Trigger({
+  isOpen,
+  setOpen,
+  count,
+}: {
+  isOpen: boolean;
+  setOpen: (value: boolean) => void;
+  count: TriggerButtonCount;
+}) {
+  const countSum = count.general + count.severe;
 
   return (
     <div
@@ -15,9 +20,7 @@ export default function Trigger({ isOpen, setOpen }: { isOpen: boolean; setOpen:
       onClick={() => setOpen(!isOpen)}
     >
       Spotlight
-      <span className={errorCount === 0 ? 'bg-indigo-300 text-indigo-600' : 'bg-red-500 text-white'}>
-        {errorCount + traceCount}
-      </span>
+      <span className={count.severe === 0 ? 'bg-indigo-300 text-indigo-600' : 'bg-red-500 text-white'}>{countSum}</span>
     </div>
   );
 }

--- a/packages/core/src/integrations/console/index.ts
+++ b/packages/core/src/integrations/console/index.ts
@@ -11,10 +11,11 @@ export default function consoleIntegration() {
   return {
     name: 'console',
     forwardedContentType: [HEADER],
-    tabs: [
+    tabs: ({ integrationData }) => [
       {
         id: 'console',
         title: 'Browser Console Logs',
+        notificationCount: integrationData[HEADER]?.length,
         content: ConsoleTab,
       },
     ],

--- a/packages/core/src/integrations/integration.ts
+++ b/packages/core/src/integrations/integration.ts
@@ -14,9 +14,9 @@ export type Integration<T = any> = {
   forwardedContentType?: string[];
 
   /**
-   * Array of tabs to be displayed in the Spotlight UI
+   * A function returning an array of tabs to be displayed in the UI.
    */
-  tabs?: IntegrationTab<T>[];
+  tabs?: TabsCreationFunction<T>;
 
   /**
    * Setup hook called when Spotlight is initialized.
@@ -31,7 +31,7 @@ export type Integration<T = any> = {
    * data structure that your integration works with in the UI.
    * The returned object will be passed to your tabs.
    */
-  processEvent?: (event: RawEvent) => T | Promise<T>;
+  processEvent?: (eventContext: RawEventContext) => T | Promise<T>;
 };
 
 export type IntegrationTab<T> = {
@@ -46,23 +46,33 @@ export type IntegrationTab<T> = {
   title: string;
 
   /**
-   * The number of events that should be displayed next to the tab's title.
+   * If this property is set, a count badge will be displayed
+   * next to the tab title with the specified value.
    */
-  count?: number;
+  notificationCount?: number;
 
   /**
    * JSX content of the tab. Go crazy, this is all yours!
    */
   content?: React.ComponentType<{
-    integrationData: Record<string, T[]>;
+    integrationData: IntegrationData<T>;
   }>;
 
-  // TODO: I don't think these should be user-facing, right?
   onSelect?: () => void;
+
+  // TODO: I don't think this should be user-facing
   active?: boolean;
 };
 
-type RawEvent = {
+type IntegrationData<T> = Record<string, T[]>;
+
+type TabsContext<T> = {
+  integrationData: IntegrationData<T>;
+};
+
+type TabsCreationFunction<T> = (context: TabsContext<T>) => IntegrationTab<T>[];
+
+type RawEventContext = {
   /**
    * The content-type header of the event
    */
@@ -76,6 +86,14 @@ type RawEvent = {
    * Return the processed object or undefined if the event should be ignored.
    */
   data: string;
+
+  /**
+   * Calling this function will tell spotlight that the processed event is a severe
+   * event that should be highlighted in the general UI.
+   *
+   * For instance, this will have an effect on the Spotlight trigger button's counter appearance.
+   */
+  markEventSevere: () => void;
 };
 
 // export type IntegrationParameter = Array<Integration<unknown>>;

--- a/packages/core/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/core/src/integrations/sentry/data/sentryDataCache.ts
@@ -27,10 +27,10 @@ class SentryDataCache {
       event_id?: string;
     })[] = [],
   ) {
-    initial.forEach(e => this.pushEvent(e));
+    initial.forEach(e => this.pushEvent(e, () => {}));
   }
 
-  pushEnvelope(envelope: Envelope) {
+  pushEnvelope(envelope: Envelope, markSevere: () => void) {
     const [header, items] = envelope;
     if (header.sdk && header.sdk.name && header.sdk.version) {
       const existingSdk = this.sdks.find(s => s.name === header.sdk!.name && s.version === header.sdk!.version);
@@ -46,7 +46,7 @@ class SentryDataCache {
     }
     items.forEach(([itemHeader, itemData]) => {
       if (itemHeader.type === 'event' || itemHeader.type === 'transaction') {
-        this.pushEvent(itemData as SentryEvent);
+        this.pushEvent(itemData as SentryEvent, markSevere);
       }
     });
   }
@@ -55,6 +55,7 @@ class SentryDataCache {
     event: SentryEvent & {
       event_id?: string;
     },
+    markSevere: () => void,
   ) {
     if (!event.event_id) event.event_id = generate_uuidv4();
 
@@ -124,6 +125,7 @@ class SentryDataCache {
       }
       this.subscribers.forEach(([type, cb]) => type === 'trace' && cb(trace));
     }
+    markSevere();
     this.subscribers.forEach(([type, cb]) => type === 'event' && cb(event));
   }
 

--- a/packages/core/src/integrations/sentry/index.ts
+++ b/packages/core/src/integrations/sentry/index.ts
@@ -19,7 +19,7 @@ export default function sentryIntegration() {
       hookIntoSentry();
     },
 
-    processEvent({ data }) {
+    processEvent({ data, markEventSevere }) {
       console.log('[spotlight] Received new envelope');
       const [rawHeader, ...rawEntries] = data.split('\n');
       const header = JSON.parse(rawHeader) as Envelope[0];
@@ -31,19 +31,22 @@ export default function sentryIntegration() {
       }
 
       const envelope = [header, items] as Envelope;
-      sentryDataCache.pushEnvelope(envelope);
+      sentryDataCache.pushEnvelope(envelope, markEventSevere);
 
       return envelope;
     },
-    tabs: [
+
+    tabs: ({ integrationData }) => [
       {
         id: 'errors',
         title: 'Errors',
+        notificationCount: integrationData['application/x-sentry-envelope']?.length,
         content: ErrorsTab,
       },
       {
         id: 'traces',
         title: 'Traces',
+        notificationCount: integrationData['application/x-sentry-envelope']?.length + 1,
         content: TracesTab,
       },
       {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -129,3 +129,8 @@ export type Sdk = {
   version: string;
   lastSeen: number;
 };
+
+export type TriggerButtonCount = {
+  general: number;
+  severe: number;
+};

--- a/packages/website/src/spotlight/snippets.ts
+++ b/packages/website/src/spotlight/snippets.ts
@@ -6,7 +6,7 @@ Spotlight.init({
     Spotlight.sentry(), 
     Spotlight.console()
   ],
-  showTriggerButton: false,
+  showTriggerButton: true,
 });
 
 setTimeout(() => {


### PR DESCRIPTION
This causes a (breaking) change in the integrations API: `tabs` will now be a function returning arrays. This function will always be called when spotlight rerenders (i.e. when a new event is sent to spotlight). By doing this, users can update the notification count for each tab individually. The count can be inferred from the passed tab context which holds the integration data (i.e. the integration's events). 

In addition this PR als re-introduces the global trigger button notification notification counter in a general manner. For this, users can specify if a processed event is "severe". In case of a severe event, the global counter's style will be changed to red. This is the generalization of how the counter appearance was previously dependent on the presence of sentry errpors (which are now severe). 

Furthermore, this PR is prework to refactoring what `processEvent` receives and returns.

Sentry integration specific: The actual count per tab is WIP; This will require more rework in the future. 


ref #19 