### PR TITLE
ref(integrations): Refactor `processEvent` and tab content props

### DIFF
--- a/.changeset/funny-adults-glow.md
+++ b/.changeset/funny-adults-glow.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/core': patch
+---
+
+ref(integrations): Adjust input and return types of `processEvent`

--- a/.changeset/rare-ladybugs-rescue.md
+++ b/.changeset/rare-ladybugs-rescue.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/core': patch
+---
+
+Removed `integrationData` prop in favour of `processedEvents` in tab component

--- a/packages/core/src/App.tsx
+++ b/packages/core/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import Debugger from './components/Debugger';
 import Trigger from './components/Trigger';
-import type { Integration } from './integrations/integration';
+import type { Integration, IntegrationData } from './integrations/integration';
 import { connectToSidecar } from './sidecar';
 import { TriggerButtonCount } from './types';
 
@@ -22,7 +22,7 @@ export default function App({
 }) {
   console.log('[Spotlight] App rerender');
 
-  const [integrationData, setIntegrationData] = useState<Record<string, Array<unknown>>>({});
+  const [integrationData, setIntegrationData] = useState<IntegrationData<unknown>>({});
   const [isOnline, setOnline] = useState(false);
   const [triggerButtonCount, setTriggerButtonCount] = useState<TriggerButtonCount>({ general: 0, severe: 0 });
 
@@ -51,7 +51,7 @@ export default function App({
       console.log('[Spotlight] useeffect cleanup');
       cleanupListeners();
     };
-  }, []);
+  }, [integrations]);
 
   const [isOpen, setOpen] = useState(fullScreen);
 

--- a/packages/core/src/components/Debugger.tsx
+++ b/packages/core/src/components/Debugger.tsx
@@ -1,4 +1,4 @@
-import { Integration } from '~/integrations/integration';
+import { Integration, IntegrationData } from '~/integrations/integration';
 import classNames from '~/lib/classNames';
 import useKeyPress from '~/lib/useKeyPress';
 import Overview from './Overview';
@@ -14,7 +14,7 @@ export default function Debugger({
   isOpen: boolean;
   setOpen: (value: boolean) => void;
   defaultEventId?: string;
-  integrationData: Record<string, Array<unknown>>;
+  integrationData: IntegrationData<unknown>;
   isOnline: boolean;
 }) {
   useKeyPress('Escape', () => {

--- a/packages/core/src/components/Overview.tsx
+++ b/packages/core/src/components/Overview.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { Integration } from '~/integrations/integration';
+import { Integration, IntegrationData } from '~/integrations/integration';
 import Tabs from './Tabs';
 
 const DEFAULT_TAB = 'errors';
@@ -10,19 +10,21 @@ export default function Overview({
   integrationData,
 }: {
   integrations: Integration[];
-  integrationData: Record<string, Array<unknown>>;
+  integrationData: IntegrationData<unknown>;
 }) {
   const [activeTab, setActiveTab] = useState(DEFAULT_TAB);
 
   const tabs = integrations
     .map(integration => {
       if (integration.tabs) {
-        return integration.tabs({ integrationData }).map(tab => ({
+        const processedEvents = integrationData[integration.name]?.map(container => container.event) || [];
+        return integration.tabs({ processedEvents }).map(tab => ({
           ...tab,
           active: activeTab === tab.id,
           onSelect: () => {
             setActiveTab(tab.id);
           },
+          processedEvents: processedEvents,
         }));
       }
       return [];
@@ -45,7 +47,7 @@ export default function Overview({
               <Route
                 path={`/${tab.id}/*`}
                 key={tab.id}
-                element={<TabContent integrationData={integrationData} key={tab.id} />}
+                element={<TabContent processedEvents={tab.processedEvents} key={tab.id} />}
               ></Route>
             );
           })}

--- a/packages/core/src/integrations/console/console-tab.tsx
+++ b/packages/core/src/integrations/console/console-tab.tsx
@@ -1,11 +1,10 @@
 import { ConsoleMessage } from './types';
 
 type Props = {
-  consoleMessages?: ConsoleMessage[];
-  integrationData: Record<string, Array<ConsoleMessage>>;
+  processedEvents?: ConsoleMessage[];
 };
-export default function ConsoleTab({ integrationData }: Props) {
-  const messages = (integrationData['application/x-spotlight-console'] || []) as ConsoleMessage[];
+export default function ConsoleTab({ processedEvents }: Props) {
+  const messages = (processedEvents || []) as ConsoleMessage[];
 
   return (
     <div className="divide-y divide-indigo-500 bg-indigo-950 p-4">

--- a/packages/core/src/integrations/console/index.ts
+++ b/packages/core/src/integrations/console/index.ts
@@ -11,11 +11,11 @@ export default function consoleIntegration() {
   return {
     name: 'console',
     forwardedContentType: [HEADER],
-    tabs: ({ integrationData }) => [
+    tabs: ({ processedEvents }) => [
       {
         id: 'console',
         title: 'Browser Console Logs',
-        notificationCount: integrationData[HEADER]?.length,
+        notificationCount: processedEvents.length,
         content: ConsoleTab,
       },
     ],
@@ -29,7 +29,9 @@ export default function consoleIntegration() {
     processEvent({ data }) {
       const msgJson = JSON.parse(data) as ConsoleMessage;
 
-      return msgJson;
+      return {
+        event: msgJson,
+      };
     },
   } satisfies Integration;
 }

--- a/packages/core/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/core/src/integrations/sentry/data/sentryDataCache.ts
@@ -27,10 +27,10 @@ class SentryDataCache {
       event_id?: string;
     })[] = [],
   ) {
-    initial.forEach(e => this.pushEvent(e, () => {}));
+    initial.forEach(e => this.pushEvent(e));
   }
 
-  pushEnvelope(envelope: Envelope, markSevere: () => void) {
+  pushEnvelope(envelope: Envelope) {
     const [header, items] = envelope;
     if (header.sdk && header.sdk.name && header.sdk.version) {
       const existingSdk = this.sdks.find(s => s.name === header.sdk!.name && s.version === header.sdk!.version);
@@ -46,7 +46,7 @@ class SentryDataCache {
     }
     items.forEach(([itemHeader, itemData]) => {
       if (itemHeader.type === 'event' || itemHeader.type === 'transaction') {
-        this.pushEvent(itemData as SentryEvent, markSevere);
+        this.pushEvent(itemData as SentryEvent);
       }
     });
   }
@@ -55,7 +55,6 @@ class SentryDataCache {
     event: SentryEvent & {
       event_id?: string;
     },
-    markSevere: () => void,
   ) {
     if (!event.event_id) event.event_id = generate_uuidv4();
 
@@ -125,7 +124,6 @@ class SentryDataCache {
       }
       this.subscribers.forEach(([type, cb]) => type === 'trace' && cb(trace));
     }
-    markSevere();
     this.subscribers.forEach(([type, cb]) => type === 'event' && cb(event));
   }
 

--- a/packages/core/src/sidecar.ts
+++ b/packages/core/src/sidecar.ts
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Integration } from './integrations/integration';
+import { Integration, IntegrationData } from './integrations/integration';
 import { TriggerButtonCount } from './types';
 
 export function connectToSidecar(
   sidecarUrl: string,
   contentTypeToIntegrations: Map<string, Integration<unknown>[]>,
-  setIntegrationData: React.Dispatch<React.SetStateAction<Record<string, Array<unknown>>>>,
+  setIntegrationData: React.Dispatch<React.SetStateAction<IntegrationData<unknown>>>,
   setOnline: React.Dispatch<React.SetStateAction<boolean>>,
   setTriggerButtonCount: React.Dispatch<React.SetStateAction<TriggerButtonCount>>,
 ): () => void {
@@ -19,27 +19,23 @@ export function connectToSidecar(
       console.log(`[spotlight] Received new ${contentType} event`);
       integrations.forEach(integration => {
         if (integration.processEvent) {
-          // TODO: This will not stay but I'll refactor it later with a better processEvent API.
-          let isSevere = false;
-          const markEventSevere = (severe: boolean = true) => {
-            isSevere = severe;
-          };
           const processedEvent = integration.processEvent({
             contentType,
             data: event.data,
-            markEventSevere,
           });
           if (processedEvent) {
             setIntegrationData(prev => {
+              const integrationName = integration.name;
               return {
                 ...prev,
-                [contentType]: [...(prev[contentType] || []), processedEvent],
+                [integrationName]: [...(prev[integrationName] || []), processedEvent],
               };
             });
             setTriggerButtonCount(prev => {
+              const keyToUpdate = processedEvent.severity === 'severe' ? 'severe' : 'general';
               return {
                 ...prev,
-                [isSevere ? 'severe' : 'general']: prev[isSevere ? 'severe' : 'general'] + 1,
+                [keyToUpdate]: prev[keyToUpdate] + 1,
               };
             });
           }
@@ -47,11 +43,11 @@ export function connectToSidecar(
       });
     };
 
+    console.log('[spotlight] adding listener for', contentType, 'sum', contentTypeListeners.length);
+
     // `contentType` could for example be "application/x-sentry-envelope"
     contentTypeListeners.push([contentType, listener]);
     source.addEventListener(contentType, listener);
-
-    console.log('[spotlight] added listener for', contentType, 'sum', contentTypeListeners.length);
   }
 
   source.addEventListener('open', () => {

--- a/packages/website/src/spotlight/snippets.ts
+++ b/packages/website/src/spotlight/snippets.ts
@@ -6,7 +6,7 @@ Spotlight.init({
     Spotlight.sentry(), 
     Spotlight.console()
   ],
-  showTriggerButton: true,
+  showTriggerButton: false,
 });
 
 setTimeout(() => {

--- a/packages/website/src/spotlight/snippets.ts
+++ b/packages/website/src/spotlight/snippets.ts
@@ -6,7 +6,7 @@ Spotlight.init({
     Spotlight.sentry(), 
     Spotlight.console()
   ],
-  showTriggerButton: false,
+  showTriggerButton: true,
 });
 
 setTimeout(() => {


### PR DESCRIPTION
This PR refactors how we internally pass integration event data to integrations and how they can produce and interact with that data.

* Internally, we still populate the reactive `integrationData` map but now it maps from integration to a list of processed events
* Integrations' `tabs` hook, as well as the `tabContent` react component receive a `processedEvents` array that only contains the integration's events. 
* the `processEvent` hook returns now a container for the processed event with additional metadata for spotlight. Currently this includes the `severity` property to support the trigger button's notification count badge 

ref #19