### PR TITLE
fix(spotlight): Re-export core from astro package

### DIFF
--- a/.changeset/real-impalas-grab.md
+++ b/.changeset/real-impalas-grab.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+Re-export core exports from astro package

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -32,3 +32,5 @@ const createPlugin = (): AstroIntegration => {
 };
 
 export default createPlugin;
+
+export * from '@spotlightjs/core';

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -1,5 +1,5 @@
 export const SPOTLIGHT_CLIENT_INIT = `
-import * as Spotlight from '@spotlightjs/core'; 
+import * as Spotlight from '@spotlightjs/astro'; 
 
 Spotlight.init({
   integrations: [


### PR DESCRIPTION
We cannot access core from a snippet because that is injected into the host app, which does not have access to dependencies dependencies.