### PR TITLE
feat(astro): Inject Spotlight into Error Pages

### DIFF
--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -33,6 +33,11 @@ ${buildClientInit(options)}
 /**
  * Hook into Vite's client code to enable Spotlight if an error occurs.
  *
+ * Main difference to normal page injection: We only initialize spotlight
+ * if an error happens and is transmitted via the websocket. This is to avoid
+ * initializing this spotlight instance before the actual app's instance.
+ * This should only be  the fallback instance if the app failed to intialize.
+ *
  * Used variables from Vite's client code:
  * - `enableOverlay` to check if the overlay should be shown
  *    @see https://github.com/vitejs/vite/blob/b9ee620108819e06023e4303af75a61d3e4e4d76/packages/vite/src/client/client.ts#L289

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -33,15 +33,11 @@ ${buildClientInit(options)}
 /**
  * Hook into Vite's client code to enable Spotlight if an error occurs.
  *
- * TODO: only init spotlight, if there isn't already a spotlight instance running!
- *       this could happen when the error overlay is shown after the pageload.
- *       For example, in an island performing an erroneous endpoint fetch
- *
- * - `enableOverlay` is defined in Vite's client code:
+ * Used variables from Vite's client code:
+ * - `enableOverlay` to check if the overlay should be shown
  *    @see https://github.com/vitejs/vite/blob/b9ee620108819e06023e4303af75a61d3e4e4d76/packages/vite/src/client/client.ts#L289
- * - `socket` is defined in Vite's client code and is used to communicate with the server:
+ * - `socket` to listen for incoming error events:
  *    @see https://github.com/vitejs/vite/blob/b9ee620108819e06023e4303af75a61d3e4e4d76/packages/vite/src/client/client.ts#L67
- *
  */
 export const buildSpotlightErrorPageSnippet = (options: ClientInitOptions) => `
 ${buildClientImport(options.importPath)}

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -1,14 +1,59 @@
-export const SPOTLIGHT_CLIENT_INIT = `
-import { init, sentry, console, viteInspect } from '@spotlightjs/astro'; 
+type SupportedIntegrations = 'sentry' | 'console' | 'viteInspect';
 
-init({
+type ClientInitOptions = {
+  importPath: string;
+  showTriggerButton?: boolean;
+  integrationNames?: SupportedIntegrations[];
+  injectImmediately?: boolean;
+};
+
+const DEFAULT_INTEGRATIONS = ['sentry', 'console', 'viteInspect'];
+
+const buildClientImport = (importPath: string) => `import * as Spotlight from '${importPath}';`;
+
+const buildClientInit = (options: ClientInitOptions) => {
+  const integrations = options.integrationNames || DEFAULT_INTEGRATIONS;
+  const integrationCalls = integrations.map(i => `Spotlight.${i}()`).join(', ');
+  return `
+Spotlight.init({
   integrations: [
-    sentry(), 
-    console(),
-    viteInspect()
+    ${integrationCalls}
   ],
-  showTriggerButton: false,
+  showTriggerButton: ${options.showTriggerButton === false ? 'false' : 'true'},
+  injectImmediately: ${options.injectImmediately === true ? 'true' : 'false'},
 });
+`;
+};
+
+export const buildClientInitSnippet = (options: ClientInitOptions) => `
+${buildClientImport(options.importPath)}
+${buildClientInit(options)}
+`;
+
+/**
+ * Hook into Vite's client code to enable Spotlight if an error occurs.
+ *
+ * TODO: only init spotlight, if there isn't already a spotlight instance running!
+ *       this could happen when the error overlay is shown after the pageload.
+ *       For example, in an island performing an erroneous endpoint fetch
+ *
+ * - `enableOverlay` is defined in Vite's client code:
+ *    @see https://github.com/vitejs/vite/blob/b9ee620108819e06023e4303af75a61d3e4e4d76/packages/vite/src/client/client.ts#L289
+ * - `socket` is defined in Vite's client code and is used to communicate with the server:
+ *    @see https://github.com/vitejs/vite/blob/b9ee620108819e06023e4303af75a61d3e4e4d76/packages/vite/src/client/client.ts#L67
+ *
+ */
+export const buildSpotlightErrorPageSnippet = (options: ClientInitOptions) => `
+${buildClientImport(options.importPath)}
+
+if (enableOverlay) {
+  socket.addEventListener('message', (event) => {
+    const dataJson = JSON.parse(event.data);
+    if (dataJson.type === 'error') {
+      ${buildClientInit(options)}
+    }
+  });
+}
 `;
 
 export const SPOTLIGHT_SERVER_SNIPPET = `
@@ -32,7 +77,6 @@ function serializeEnvelope(envelope) {
 
 // A very hacky way to hook into Sentry's SDK
 // but we love hacks
-console.log('[Spotlight]', globalThis.__SENTRY__);
 (globalThis).__SENTRY__.hub._stack[0].client.setupIntegrations(true);
 (globalThis).__SENTRY__.hub._stack[0].client.on(
   "beforeEnvelope",
@@ -49,5 +93,4 @@ console.log('[Spotlight]', globalThis.__SENTRY__);
     });
   }
 );
-
 `;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,3 +2,7 @@ export type TriggerButtonCount = {
   general: number;
   severe: number;
 };
+
+export type WindowWithSpotlight = Window & {
+  __spotlight_initialized?: boolean;
+};

--- a/packages/playground/astro.config.mjs
+++ b/packages/playground/astro.config.mjs
@@ -17,27 +17,7 @@ export default defineConfig({
       sourcemap: true,
     },
     server: {},
-    plugins: [
-      {
-        id: 'test-plugin',
-        transform(code, id) {
-          //   if (code.includes("error")) {
-          //     console.log("----------");
-          //     console.log(code);
-          //   }
-          return code;
-        },
-        configureServer(server) {
-          server.middlewares.use((err, req, res, next) => {
-            console.log('----------');
-            console.log({
-              err,
-            });
-            next();
-          });
-        },
-      },
-    ],
+    plugins: [],
   },
   adapter: node({
     mode: 'standalone',

--- a/packages/playground/src/pages/ssr-error/index.astro
+++ b/packages/playground/src/pages/ssr-error/index.astro
@@ -1,7 +1,9 @@
 ---
 import {GET} from '../api/hello.ts'
 
+// @ts-ignore
 let response = await GET(Astro)
+// @ts-ignore
 const data = await response.json()
 ---
 


### PR DESCRIPTION
This PR adds Spotlight to error pages that are generated by Vite if a server-side error occurs that hinders the actual project content from being rendered on the client (e.g. SSR errors that let ssr fail). Previously, these pages didn't get spotlight because spotlight was only included in Astro's client page code. 

With this change, we now also inject ourselves into the error page bundle by:
* Adding a Vite plugin that transforms Vite's `client.js` script (which is always included, also in error pages) so that
  * we check if Vite's error overlay should be shown
  * we hook ourselves into Vite's websocket connection and listen for error events (the same error events that trigger the error overlay)
  * in case of an error event, we initialize spotlight and inject it into the page

This required some changes in core spotlight to get everything working correctly:
- added an `injectImmediately` option that avoids listening to `window.load` to inject the spotlight shadow root but directly does it when `Spotlight.init`. This defaults to `false` but we set it to true for the Vite client bundle because `load` was already fired by the time that Spotlight.init was called.
- added a global `__spotlight_initialized` flag to avoid double intialization of Spotlight. This could happen when the error overlay is shown when the client app is already loaded and working. For example in a server error triggered by an island component.