### PR TITLE
fix(astro): Fix type in package.json keywords

### DIFF
--- a/.changeset/witty-chefs-sort.md
+++ b/.changeset/witty-chefs-sort.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+fix(astro): Fix type in package.json keywords

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -6,7 +6,7 @@
   "author": "Sentry",
   "repository": "git@github.com:getsentry/spotlight.git",
   "homepage": "https://github.com/getsentry/spotlight/blob/main/packages/astro/README.md",
-  "keywors": [
+  "keywords": [
     "astro",
     "withastro",
     "astro-component",


### PR DESCRIPTION
This explains why `npx astro add @spotlighths/astro` didn't work