### PR TITLE
feat: Add Sidecar `connect` function

### DIFF
--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -25,6 +25,9 @@
     "./vite-plugin": {
       "import": "./src/vite-plugin.js"
     },
+    "./connect": {
+      "import": "./src/connect.js"
+    },
     "./run": {
       "import": "./src/run.js"
     }

--- a/packages/sidecar/src/connect.js
+++ b/packages/sidecar/src/connect.js
@@ -1,0 +1,34 @@
+function serializeEnvelope(envelope) {
+  const [envHeaders, items] = envelope;
+
+  // Initially we construct our envelope as a string and only convert to binary chunks if we encounter binary data
+  const parts = [];
+  parts.push(JSON.stringify(envHeaders));
+
+  for (const item of items) {
+    const [itemHeaders, payload] = item;
+
+    parts.push('\\n' + JSON.stringify(itemHeaders) + '\\n');
+
+    parts.push(JSON.stringify(payload));
+  }
+
+  return parts.join('');
+}
+export function connect(hub) {
+  // A very hacky way to hook into Sentry's SDK
+  // but we love hacks
+  hub._stack[0].client.setupIntegrations(true);
+  hub._stack[0].client.on('beforeEnvelope', envelope => {
+    fetch('http://localhost:8969/stream', {
+      method: 'POST',
+      body: serializeEnvelope(envelope),
+      headers: {
+        'Content-Type': 'application/x-sentry-envelope',
+      },
+      mode: 'cors',
+    }).catch(() => {
+      console.warn('[Spotlight] Failed to send envelope to Spotlight Sidecar');
+    });
+  });
+}


### PR DESCRIPTION
To hook into Sentry's Node SDK this is what you have to do:

```js
import * as Sentry from '@sentry/node';
import { connect } from '@spotlightjs/sidecar/connect'

Sentry.init({debug: true});
connect(Sentry.getCurrentHub()); // After Sentry init, call connect and pass the hub
...
Sentry.captureMessage('Something went wrong');
```

ref: https://github.com/getsentry/spotlight/issues/76