### PR TITLE
fix(core): Cleanup spotlight event target listeners

### DIFF
--- a/.changeset/seven-carrots-shop.md
+++ b/.changeset/seven-carrots-shop.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/core': patch
+---
+
+fix(core): Use effect and cleanup spotlight event target listeners

--- a/packages/core/src/App.tsx
+++ b/packages/core/src/App.tsx
@@ -56,13 +56,23 @@ export default function App({
     };
   }, [integrations, sidecar]);
 
-  eventTarget.addEventListener('open', () => {
-    setOpen(true);
-  });
+  useEffect(() => {
+    const onOpen = () => {
+      setOpen(true);
+    };
 
-  eventTarget.addEventListener('close', () => {
-    setOpen(false);
-  });
+    const onClose = () => {
+      setOpen(false);
+    };
+
+    eventTarget.addEventListener('open', onOpen);
+    eventTarget.addEventListener('close', onClose);
+
+    return () => {
+      eventTarget.removeEventListener('open', onOpen);
+      eventTarget.removeEventListener('close', onClose);
+    };
+  }, [eventTarget]);
 
   useEffect(() => {
     if (!isOpen) {


### PR DESCRIPTION
Looks like we registered event listeners on every app rerender and for some reason this f*ed with setting the open state. 

(I think it's obvious by now that I have no idea about React lol)

let's merge this, release and see if it's really fixed

possibly resolves #68 