### PR TITLE
Uniform package names

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@spotlightjs/spotlight-astro-playground", "@spotlightjs/spotlight-website"]
+  "ignore": ["@spotlightjs/astro-playground", "@spotlightjs/website"]
 }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "type": "module",
   "scripts": {
     "dev:core": "pnpm --filter core dev",
-    "dev:website": "pnpm --filter spotlight-website dev",
-    "dev:playground": "pnpm --filter spotlight-astro-playground dev",
-    "build": "pnpm --filter=!spotlight-astro-playground -r run build",
+    "dev:website": "pnpm --filter website dev",
+    "dev:playground": "pnpm --filter astro-playground dev",
+    "build": "pnpm --filter=!astro-playground -r run build",
     "preview": "pnpm -r run preview",
     "lint": "eslint . --cache --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preinstall": "npx only-allow pnpm",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spotlightjs/spotlight-astro-playground",
+  "name": "@spotlightjs/astro-playground",
   "description": "Playground for testing Spotlight in an Astro SSR app with islands",
   "type": "module",
   "version": "0.0.0",

--- a/packages/website/CHANGELOG.md
+++ b/packages/website/CHANGELOG.md
@@ -1,4 +1,4 @@
-# @spotlightjs/spotlight-website
+# @spotlightjs/website
 
 ## 0.0.1
 

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@spotlightjs/spotlight-website",
+  "name": "@spotlightjs/website",
   "type": "module",
   "license": "Apache-2.0",
   "private": true,


### PR DESCRIPTION
Remove spotlight- prefix on website and astro-playground.