### PR TITLE
fix(docs): typos fixed and added a extension recommendation for vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,4 @@
 {
-  "recommendations": [],
+  "recommendations": ["streetsidesoftware.code-spell-checker"],
   "unwantedRecommendations": []
 }

--- a/packages/website/src/content/docs/about.mdx
+++ b/packages/website/src/content/docs/about.mdx
@@ -40,7 +40,7 @@ npx @spotlightjs/sidecar
 ```
 
 The overlay itself behaves a little differently from Sentry. That's intentional both because this is for local
-development, but also because the project is completely indepedent of Sentry (other than our guaranteed support).
+development, but also because the project is completely independent of Sentry (other than our guaranteed support).
 
 Spotlight can show you errors, traces, configurations settings, installed dependencies, you name it. Spotlight is developed with customizablity in mind, so you can add your own integrations to it.
 

--- a/packages/website/src/content/docs/architecture.mdx
+++ b/packages/website/src/content/docs/architecture.mdx
@@ -9,13 +9,13 @@ import Architecture from "../../../public/images/architecture.png";
 
 ### Description
 
-Spotlight consists of 2 main components. The UI that is embeded in your Website. 
+Spotlight consists of 2 main components. The UI that is embedded in your Website. 
 And a Sidecar (Proxy) that streams incoming events to the UI.
 
 You can send any kind of events to the Sidecar, it forwards it to Spotlight and the integrations within Spotlight need to understand what to do with it.
 
 <LinkCard title="Sidecar" description="Understand what the sidecar does" href="/sidecar/" />
 
-Spotlight by default has a Sentry integration, if you are using a Sentry SDK and enable the Spotliht connection (only required on the Server), Spotlight is able
+Spotlight by default has a Sentry integration, if you are using a Sentry SDK and enable the Spotlight connection (only required on the Server), Spotlight is able
 to render Traces/Errors and more in your frontend.
 

--- a/packages/website/src/content/docs/contribute/changesets.mdx
+++ b/packages/website/src/content/docs/contribute/changesets.mdx
@@ -5,7 +5,7 @@ description: How-to commit to Spotlight.
 
 Spotlight uses [Changesets](https://github.com/changesets/changesets) to track changes & versions.
 
-Whenever you make a change that is users facing, you should add a changeset to your PR. You can do this by runing the
+Whenever you make a change that is users facing, you should add a changeset to your PR. You can do this by running the
 following command:
 
 ```shell

--- a/packages/website/src/content/docs/integrations/build-your-own.mdx
+++ b/packages/website/src/content/docs/integrations/build-your-own.mdx
@@ -28,7 +28,7 @@ First the integration needs a name `name: 'sentry'`.
 
 **Setup**
 
-Next up, we have an optional function that is invoked during initalization of Spotlight called `setup`.
+Next up, we have an optional function that is invoked during initialization of Spotlight called `setup`.
 In Sentry's case we try to find a running Browser SDK and hook into it to tell it to send events to the Sidecar.
 
 **How does an integration receive events?**

--- a/packages/website/src/content/docs/reference/integration.md
+++ b/packages/website/src/content/docs/reference/integration.md
@@ -1,6 +1,6 @@
 ---
 title: Integration
-description: Interface of an intergration
+description: Interface of an integration
 ---
 
 ```ts


### PR DESCRIPTION
fixes: #135 


- Fixed some typos in docs
- Added a Spell Checker Extension recommendation for vscode.