### PR TITLE
Ruby SDK version requirement: update to 5.15

### DIFF
--- a/packages/website/src/content/docs/setup/sentry.mdx
+++ b/packages/website/src/content/docs/setup/sentry.mdx
@@ -56,7 +56,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   </TabItem>
   <TabItem label="Ruby">
   :::caution
-  Requires `sentry-ruby` version `5.14.0` or higher.
+  Requires `sentry-ruby` version `5.15.0` or higher.
   :::
   ```ruby 
     Sentry.init do |config|


### PR DESCRIPTION
## Summary

Got to love PRs with one character change! This updates required sentry-ruby version from 5.14 to 5.15.

5.14 shipped today without Spotlight support. So 5.15 is optimistic, assuming we merge https://github.com/getsentry/sentry-ruby/pull/2175 soon enough and ship it.

## Review

Welp, saying Spotlight requires a version of SDK that haven't shipped yet is slightly suspicious, but I think it's better than saying things work on 5.14. Plus, there's not a whole lot of people on that website just yet, right? 

/cc @HazAT 