### PR TITLE
ref(astro): Use Spotlight integration on server-side instead of custom code

### DIFF
--- a/.changeset/metal-hotels-brake.md
+++ b/.changeset/metal-hotels-brake.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+ref(astro): Use Spotlight integration on server-side instead of custom code

--- a/demos/astro-playground/astro.config.mjs
+++ b/demos/astro-playground/astro.config.mjs
@@ -27,6 +27,9 @@ export default defineConfig({
     react({ include: ['**/react/*'] }),
     sentry({
       debug: true,
+      sourceMapsUploadOptions: {
+        enabled: false, // tmp deactivate until version after 7.83.0
+      },
     }),
     spotlight(),
   ],

--- a/demos/astro-playground/src/middleware.ts
+++ b/demos/astro-playground/src/middleware.ts
@@ -1,3 +1,0 @@
-import { handleRequest } from '@sentry/astro';
-
-export const onRequest = handleRequest();

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -56,10 +56,8 @@ const createPlugin = (options?: SpotlightOptions): AstroIntegration => {
           const importPath = path.dirname(url.fileURLToPath(import.meta.url));
           const pluginPath = path.join(importPath, 'overlay/index.ts');
           addDevOverlayPlugin(pluginPath);
-        } else {
-          if (options?.__debugOptions) {
-            injectScript('page', buildClientInitSnippet(options.__debugOptions));
-          }
+        } else if (options?.__debugOptions) {
+          injectScript('page', buildClientInitSnippet(options.__debugOptions));
         }
       },
 

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -59,40 +59,7 @@ if (enableOverlay) {
 `;
 
 export const SPOTLIGHT_SERVER_SNIPPET = `
-function serializeEnvelope(envelope) {
-  const [envHeaders, items] = envelope;
-
-  // Initially we construct our envelope as a string and only convert to binary chunks if we encounter binary data
-  const parts = [];
-  parts.push(JSON.stringify(envHeaders));
-
-  for (const item of items) {
-    const [itemHeaders, payload] = item;
-
-    parts.push('\\n' + JSON.stringify(itemHeaders)+ '\\n');
-
-    parts.push(JSON.stringify(payload));
-  }
-
-  return parts.join("");
-}
-
-// A very hacky way to hook into Sentry's SDK
-// but we love hacks
-(globalThis).__SENTRY__.hub._stack[0].client.setupIntegrations(true);
-(globalThis).__SENTRY__.hub._stack[0].client.on(
-  "beforeEnvelope",
-  (envelope) => {
-    fetch("http://localhost:8969/stream", {
-      method: "POST",
-      body: serializeEnvelope(envelope),
-      headers: {
-        "Content-Type": "application/x-sentry-envelope",
-      },
-      mode: "cors",
-    }).catch((err) => {
-      console.error('[Spotlight]', err);
-    });
-  }
-);
+import * as _SentrySDKForSpotlight from '@sentry/astro';
+_SentrySDKForSpotlight.getClient().setupIntegrations(true);
+_SentrySDKForSpotlight.addIntegration(new _SentrySDKForSpotlight.Integrations.Spotlight());
 `;


### PR DESCRIPTION
This PR refactors hooking into server-side Sentry in astro apps. In contrast to regular Node apps, users don't need to set `spotlight: true` in their Astro SDK because we can simply add the integration in the Astro Spotlight integration. This removes the custom hack we had before that accesses the Sentry client via the global object.

I'll open a follow-up PR to pass a custom sidecar URL to the server snippet 