### PR TITLE
feat: Add support for custom sidecar URL on client side Sentry integration

### DIFF
--- a/.changeset/hungry-dryers-hear.md
+++ b/.changeset/hungry-dryers-hear.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/overlay': patch
+'@spotlightjs/astro': patch
+---
+
+feat(core): Add support for custom sidecar URL in client Sentry integration

--- a/.changeset/lucky-fireants-whisper.md
+++ b/.changeset/lucky-fireants-whisper.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+feat(astro): Add custom `sidecarUrl` option

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -1,5 +1,5 @@
 import type { AstroIntegration } from 'astro';
-import { SPOTLIGHT_SERVER_SNIPPET, buildClientInitSnippet, type ClientInitOptions } from './snippets';
+import { buildClientInitSnippet, buildServerSnippet, type ClientInitOptions } from './snippets';
 
 import path from 'path';
 import url from 'url';
@@ -11,7 +11,22 @@ const PKG_NAME = '@spotlightjs/astro';
 export type SpotlightOptions =
   | {
       __debugOptions?: ClientInitOptions;
+
+      /**
+       * If enabled, Spotlight will log additional debug output to the console.
+       */
       debug: boolean;
+
+      /**
+       * Set this URL if you're running the Spotlight sidecar on a custom URL.
+       * Setting this URL will cause server- and client-side events to be forwarded to the sidcar running on the passed URL.
+       *
+       * IMPORTANT: This option assumes that you manually started the sidecar outside of Astro. Therefore, if it is set,
+       * the spotlight Astro integration will not start its own sidecar.
+       *
+       * @default 'http://localhost:8969/stream'
+       */
+      sidecarUrl?: string;
     }
   | undefined;
 
@@ -51,7 +66,7 @@ const createPlugin = (options?: SpotlightOptions): AstroIntegration => {
           }
 
           injectScript('page', buildClientInitSnippet({ importPath: PKG_NAME, showTriggerButton, ...options }));
-          injectScript('page-ssr', SPOTLIGHT_SERVER_SNIPPET);
+          injectScript('page-ssr', buildServerSnippet({ sidecarUrl: options?.sidecarUrl }));
 
           const importPath = path.dirname(url.fileURLToPath(import.meta.url));
           const pluginPath = path.join(importPath, 'overlay/index.ts');

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -45,13 +45,13 @@ const createPlugin = (options?: SpotlightAstroIntegrationOptions): AstroIntegrat
           }
 
           injectScript('page', buildClientInitSnippet({ importPath: PKG_NAME, showTriggerButton, ...options }));
-          injectScript('page-ssr', buildServerSnippet({ sidecarUrl: options?.sidecarUrl }));
+          injectScript('page-ssr', buildServerSnippet(options));
 
           const importPath = path.dirname(url.fileURLToPath(import.meta.url));
           const pluginPath = path.join(importPath, 'overlay/index.ts');
           addDevOverlayPlugin(pluginPath);
         } else if (options?.__debugOptions) {
-          injectScript('page', buildClientInitSnippet(options.__debugOptions));
+          injectScript('page', buildClientInitSnippet({ importPath: PKG_NAME, ...options }));
         }
       },
 

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -1,3 +1,5 @@
+import type { SpotlightAstroIntegrationOptions } from './types';
+
 type SupportedIntegrations = 'sentry' | 'console' | 'viteInspect';
 
 export type ClientInitOptions = {
@@ -5,7 +7,7 @@ export type ClientInitOptions = {
   showTriggerButton?: boolean;
   integrationNames?: SupportedIntegrations[];
   injectImmediately?: boolean;
-};
+} & SpotlightAstroIntegrationOptions;
 
 const DEFAULT_INTEGRATIONS = ['sentry'];
 
@@ -22,6 +24,7 @@ Spotlight.init({
   showTriggerButton: ${options.showTriggerButton === false ? 'false' : 'true'},
   injectImmediately: ${options.injectImmediately === true ? 'true' : 'false'},
   debug: ${options.debug === true ? 'true' : 'false'},
+  ${options.sidecarUrl ? `sidecarUrl: '${options.sidecarUrl}'` : ''}
 });
 `;
 };

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -58,8 +58,15 @@ if (enableOverlay) {
 }
 `;
 
-export const SPOTLIGHT_SERVER_SNIPPET = `
+type ServerSnippetOptions = {
+  sidecarUrl?: string;
+};
+
+export const buildServerSnippet: (options: ServerSnippetOptions) => string = ({ sidecarUrl }) => `
 import * as _SentrySDKForSpotlight from '@sentry/astro';
+
 _SentrySDKForSpotlight.getClient().setupIntegrations(true);
-_SentrySDKForSpotlight.addIntegration(new _SentrySDKForSpotlight.Integrations.Spotlight());
+_SentrySDKForSpotlight.addIntegration(new _SentrySDKForSpotlight.Integrations.Spotlight({
+  ${sidecarUrl ? `sidecarUrl: '${sidecarUrl}'` : ''}
+}));
 `;

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -9,13 +9,13 @@ export type ClientInitOptions = {
   injectImmediately?: boolean;
 } & SpotlightAstroIntegrationOptions;
 
-const DEFAULT_INTEGRATIONS = ['sentry'];
-
 const buildClientImport = (importPath: string) => `import * as Spotlight from '${importPath}';`;
 
 const buildClientInit = (options: ClientInitOptions) => {
-  const integrations = options.integrationNames || DEFAULT_INTEGRATIONS;
-  const integrationCalls = integrations.map(i => `Spotlight.${i}()`).join(', ');
+  const integrationCalls = options.integrationNames
+    ? options.integrationNames.map(i => `Spotlight.${i}()`).join(', ')
+    : `Spotlight.sentry({sidecarUrl: ${options.sidecarUrl ? `'${options.sidecarUrl}'` : undefined}})`;
+
   return `
 Spotlight.init({
   integrations: [
@@ -24,7 +24,7 @@ Spotlight.init({
   showTriggerButton: ${options.showTriggerButton === false ? 'false' : 'true'},
   injectImmediately: ${options.injectImmediately === true ? 'true' : 'false'},
   debug: ${options.debug === true ? 'true' : 'false'},
-  ${options.sidecarUrl ? `sidecarUrl: '${options.sidecarUrl}'` : ''}
+  ${options.sidecarUrl ? `sidecar: '${options.sidecarUrl}'` : ''}
 });
 `;
 };
@@ -61,15 +61,11 @@ if (enableOverlay) {
 }
 `;
 
-type ServerSnippetOptions = {
-  sidecarUrl?: string;
-};
-
-export const buildServerSnippet: (options: ServerSnippetOptions) => string = ({ sidecarUrl }) => `
+export const buildServerSnippet: (options: SpotlightAstroIntegrationOptions) => string = options => `
 import * as _SentrySDKForSpotlight from '@sentry/astro';
 
 _SentrySDKForSpotlight.getClient().setupIntegrations(true);
 _SentrySDKForSpotlight.addIntegration(new _SentrySDKForSpotlight.Integrations.Spotlight({
-  ${sidecarUrl ? `sidecarUrl: '${sidecarUrl}'` : ''}
+  ${options?.sidecarUrl ? `sidecarUrl: '${options.sidecarUrl}'` : ''}
 }));
 `;

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -14,7 +14,7 @@ export type SpotlightAstroIntegrationOptions =
       /**
        * If enabled, Spotlight will log additional debug output to the console.
        */
-      debug: boolean;
+      debug?: boolean;
 
       /**
        * Additional debug options.

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -1,0 +1,25 @@
+export type SpotlightAstroIntegrationOptions =
+  | {
+      /**
+       * Set this URL if you're running the Spotlight sidecar on a custom URL.
+       * Setting this URL will cause server- and client-side events to be forwarded to the sidcar running on the passed URL.
+       *
+       * IMPORTANT: This option assumes that you manually started the sidecar outside of Astro. Therefore, if it is set,
+       * the spotlight Astro integration will not start its own sidecar.
+       *
+       * @default 'http://localhost:8969/stream'
+       */
+      sidecarUrl?: string;
+
+      /**
+       * If enabled, Spotlight will log additional debug output to the console.
+       */
+      debug: boolean;
+
+      /**
+       * Additional debug options.
+       * WARNING: These options are not part of the public API and may change at any time.
+       */
+      __debugOptions?: Record<string, unknown>;
+    }
+  | undefined;

--- a/packages/astro/src/vite/error-page.ts
+++ b/packages/astro/src/vite/error-page.ts
@@ -1,12 +1,13 @@
 import { buildSpotlightErrorPageSnippet } from '../snippets';
 
 import type { Plugin } from 'vite';
+import type { SpotlightAstroIntegrationOptions } from '../types';
 
 type ErrorPagePluginOptions = {
   importPath: string;
-};
+} & SpotlightAstroIntegrationOptions;
 
-export const errorPageInjectionPlugin: (options: ErrorPagePluginOptions) => Plugin = ({ importPath }) => {
+export const errorPageInjectionPlugin: (options: ErrorPagePluginOptions) => Plugin = options => {
   return {
     name: 'spotlight-vite-client-snippet-plugin',
     transform(code, id, opts = {}) {
@@ -14,7 +15,7 @@ export const errorPageInjectionPlugin: (options: ErrorPagePluginOptions) => Plug
       if (!id.includes('vite/dist/client/client.mjs')) return;
 
       const initSnippet = buildSpotlightErrorPageSnippet({
-        importPath,
+        ...options,
         // Astro's toolbar isn't available in the error page
         showTriggerButton: true,
         // don't wait for the window.load event to be fired because in the error page,

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -48,12 +48,12 @@ const DEFAULT_SIDECAR = 'http://localhost:8969/stream';
 export async function init({
   fullScreen = false,
   showTriggerButton = true,
-  integrations = [sentry()],
   defaultEventId,
   injectImmediately = false,
   sidecar = DEFAULT_SIDECAR,
   anchor = DEFAULT_ANCHOR,
   debug = false,
+  integrations,
 }: {
   integrations?: Integration[];
   fullScreen?: boolean;
@@ -77,7 +77,11 @@ export async function init({
   if (debug) {
     activateLogger();
   }
-  const initializedIntegrations = await initIntegrations(integrations);
+
+  // Sentry is enabled by default
+  const defaultInitegrations = [sentry({ sidecarUrl: sidecar })];
+
+  const initializedIntegrations = await initIntegrations(integrations ?? defaultInitegrations);
 
   // build shadow dom container to contain styles
   const docRoot = document.createElement('div');

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -10,13 +10,17 @@ import TracesTab from './tabs/TracesTab';
 
 const HEADER = 'application/x-sentry-envelope';
 
-export default function sentryIntegration() {
+type SentryIntegrationOptions = {
+  sidecarUrl?: string;
+};
+
+export default function sentryIntegration(options?: SentryIntegrationOptions) {
   return {
     name: 'sentry',
     forwardedContentType: [HEADER],
 
     setup: () => {
-      addSpotlightIntegrationToSentry();
+      addSpotlightIntegrationToSentry(options);
     },
 
     processEvent: (event: RawEventContext) => processEnvelope(event),
@@ -89,12 +93,15 @@ function isErrorEnvelope(envelope: Envelope) {
   return envelope[1].some(([itemHeader]) => itemHeader.type === 'event');
 }
 
-function addSpotlightIntegrationToSentry() {
+function addSpotlightIntegrationToSentry(options?: SentryIntegrationOptions) {
   // A very hacky way to hook into Sentry's SDK
   // but we love hacks
   const sentryHub = (window as WindowWithSentry).__SENTRY__?.hub;
   const sentryClient = sentryHub?.getClient();
   if (sentryClient) {
-    sentryClient.addIntegration(new Spotlight());
+    const spotlightIntegration = new Spotlight({
+      sidecarUrl: options?.sidecarUrl,
+    });
+    sentryClient.addIntegration(spotlightIntegration);
   }
 }


### PR DESCRIPTION
Turns out, we didn't yet support custom sidecar urls in the client side integration, meaning client side events didn't get forwarded correctly. This PR now adds support and propagates this support further to the Astro integration. 

This also adds some well-needed cleanup of astro integration types

closes #159 which turned out to be way more complicated than I thought b/c it wasn't yet supported in the overlay