### PR TITLE
chore(astro): Include Astro 4.x preview versions in peer dep range

### DIFF
--- a/.changeset/breezy-suns-sell.md
+++ b/.changeset/breezy-suns-sell.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+chore(astro): Include Astro 4.0.0 preview versions in peer dependency range

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -27,7 +27,7 @@
     ".": "./src/index.ts"
   },
   "peerDependencies": {
-    "astro": ">=3.4.0"
+    "astro": ">=3.4.0 || >=4.0.0-beta"
   },
   "dependencies": {
     "@spotlightjs/overlay": "workspace:*",


### PR DESCRIPTION
see https://github.com/getsentry/sentry-javascript/pull/9696
