### PR TITLE
fix(website): Adjust Starlight `color-gray-7` color value

### DIFF
--- a/packages/website/src/theme.css
+++ b/packages/website/src/theme.css
@@ -22,6 +22,7 @@ dialog {
   --sl-color-gray-4: hsl(224, 7%, 36%);
   --sl-color-gray-5: hsl(228, 13%, 23%);
   --sl-color-gray-6: hsl(249, 29%, 13%);
+  --sl-color-gray-7: hsl(245, 30%, 8%);
   --sl-color-black: hsl(249, 36%, 9%);
   --sl-color-text-accent: var(--sl-color-accent-high);
   --sl-color-text-invert: var(--sl-color-accent-low);


### PR DESCRIPTION
This fixes e.g. the card background on hover or certain header elements being too bright

fixes #168
