### PR TITLE
ref(overlay): Rename `sidecar` option to `sidecarUrl`

### DIFF
--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -24,7 +24,7 @@ Spotlight.init({
   showTriggerButton: ${options.showTriggerButton === false ? 'false' : 'true'},
   injectImmediately: ${options.injectImmediately === true ? 'true' : 'false'},
   debug: ${options.debug === true ? 'true' : 'false'},
-  ${options.sidecarUrl ? `sidecar: '${options.sidecarUrl}'` : ''}
+  ${options.sidecarUrl ? `sidecarUrl: '${options.sidecarUrl}'` : ''}
 });
 `;
 };

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -12,7 +12,7 @@ type AppProps = {
   showTriggerButton?: boolean;
   defaultEventId?: string;
   integrations?: Integration[];
-  sidecar: string;
+  sidecarUrl: string;
   anchor?: Anchor;
 };
 
@@ -21,7 +21,7 @@ export default function App({
   showTriggerButton = true,
   defaultEventId,
   integrations = [],
-  sidecar,
+  sidecarUrl,
   anchor,
 }: AppProps) {
   log('App rerender');
@@ -45,7 +45,7 @@ export default function App({
     );
 
     const cleanupListeners = connectToSidecar(
-      sidecar,
+      sidecarUrl,
       contentTypeToIntegrations,
       setIntegrationData,
       setOnline,
@@ -56,7 +56,7 @@ export default function App({
       log('useEffect cleanup');
       cleanupListeners();
     };
-  }, [integrations, sidecar]);
+  }, [integrations, sidecarUrl]);
 
   const spotlightEventTarget = getSpotlightEventTarget();
 

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -60,14 +60,14 @@ export async function onSevereEvent(cb: (count: number) => void) {
   });
 }
 
-const DEFAULT_SIDECAR = 'http://localhost:8969/stream';
+const DEFAULT_SIDECAR_URL = 'http://localhost:8969/stream';
 
 export async function init({
   fullScreen = false,
   showTriggerButton = true,
   defaultEventId,
   injectImmediately = false,
-  sidecar = DEFAULT_SIDECAR,
+  sidecarUrl = DEFAULT_SIDECAR_URL,
   anchor = DEFAULT_ANCHOR,
   debug = false,
   integrations,
@@ -86,7 +86,7 @@ export async function init({
   }
 
   // Sentry is enabled by default
-  const defaultInitegrations = [sentry({ sidecarUrl: sidecar })];
+  const defaultInitegrations = [sentry({ sidecarUrl })];
 
   const initializedIntegrations = await initIntegrations(integrations ?? defaultInitegrations);
 
@@ -117,7 +117,7 @@ export async function init({
       fullScreen={fullScreen}
       defaultEventId={defaultEventId}
       showTriggerButton={showTriggerButton}
-      sidecar={sidecar}
+      sidecarUrl={sidecarUrl}
       anchor={anchor}
     />,
     // </React.StrictMode>

--- a/packages/overlay/src/sidecar.ts
+++ b/packages/overlay/src/sidecar.ts
@@ -4,14 +4,14 @@ import { log } from './lib/logger';
 import { TriggerButtonCount } from './types';
 
 export function connectToSidecar(
-  sidecar: string,
+  sidecarUrl: string,
   contentTypeToIntegrations: Map<string, Integration<unknown>[]>,
   setIntegrationData: React.Dispatch<React.SetStateAction<IntegrationData<unknown>>>,
   setOnline: React.Dispatch<React.SetStateAction<boolean>>,
   setTriggerButtonCount: React.Dispatch<React.SetStateAction<TriggerButtonCount>>,
 ): () => void {
-  log('Connecting to sidecar at', sidecar);
-  const source = new EventSource(sidecar);
+  log('Connecting to sidecar at', sidecarUrl);
+  const source = new EventSource(sidecarUrl);
 
   const contentTypeListeners: [contentType: string, listener: (event: MessageEvent) => void][] = [];
 

--- a/packages/overlay/src/types.ts
+++ b/packages/overlay/src/types.ts
@@ -74,11 +74,6 @@ export type SpotlightOverlayOptions = {
    * TODO: Remove? No longer needed with new approach
    */
   defaultEventId?: string;
-
-  /**
-   * TODO: Remove! duplicate of `sidecarUrl`
-   */
-  sidecar?: string;
 };
 
 export type TriggerButtonCount = {


### PR DESCRIPTION
This PR renames the top level `sidecar` option to `sidecarUrl` because
- the new name much better describes the options purpose
- we use sidecarUrl in the Sentry integrations and in the spotlight sentry integration
