### PR TITLE
ref(overlay): Rename `fullscreen` option to `openOnInit`

### DIFF
--- a/.changeset/polite-glasses-add.md
+++ b/.changeset/polite-glasses-add.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+ref(overlay): Rename `fullscreen` option to `openOnInit`

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -1,23 +1,17 @@
 import { useEffect, useState } from 'react';
 import Debugger from './components/Debugger';
-import Trigger, { type Anchor } from './components/Trigger';
+import Trigger from './components/Trigger';
 import type { Integration, IntegrationData } from './integrations/integration';
 import { getSpotlightEventTarget } from './lib/eventTarget';
 import { log } from './lib/logger';
 import { connectToSidecar } from './sidecar';
-import { TriggerButtonCount } from './types';
+import { SpotlightOverlayOptions, TriggerButtonCount } from './types';
 
-type AppProps = {
-  fullScreen?: boolean;
-  showTriggerButton?: boolean;
-  defaultEventId?: string;
-  integrations?: Integration[];
-  sidecarUrl: string;
-  anchor?: Anchor;
-};
+type AppProps = Omit<SpotlightOverlayOptions, 'debug' | 'injectImmediately'> &
+  Required<Pick<SpotlightOverlayOptions, 'sidecarUrl'>>;
 
 export default function App({
-  fullScreen = false,
+  openOnInit = false,
   showTriggerButton = true,
   defaultEventId,
   integrations = [],
@@ -29,7 +23,7 @@ export default function App({
   const [integrationData, setIntegrationData] = useState<IntegrationData<unknown>>({});
   const [isOnline, setOnline] = useState(false);
   const [triggerButtonCount, setTriggerButtonCount] = useState<TriggerButtonCount>({ general: 0, severe: 0 });
-  const [isOpen, setOpen] = useState(fullScreen);
+  const [isOpen, setOpen] = useState(openOnInit);
 
   useEffect(() => {
     // Map that holds the information which kind of content type should be dispatched to which integration(s)

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -63,7 +63,7 @@ export async function onSevereEvent(cb: (count: number) => void) {
 const DEFAULT_SIDECAR_URL = 'http://localhost:8969/stream';
 
 export async function init({
-  fullScreen = false,
+  openOnInit = false,
   showTriggerButton = true,
   defaultEventId,
   injectImmediately = false,
@@ -114,7 +114,7 @@ export async function init({
     // <React.StrictMode>
     <App
       integrations={initializedIntegrations}
-      fullScreen={fullScreen}
+      openOnInit={openOnInit}
       defaultEventId={defaultEventId}
       showTriggerButton={showTriggerButton}
       sidecarUrl={sidecarUrl}

--- a/packages/overlay/src/types.ts
+++ b/packages/overlay/src/types.ts
@@ -15,16 +15,6 @@ export type SpotlightOverlayOptions = {
   integrations?: Integration[];
 
   /**
-   * TODO: Rename
-   *
-   * If set to `true`, the Spotlight overlay Window will be opened immediately
-   * after calling the init.
-   *
-   * @default false - only the Spotlight button is visible.
-   */
-  fullScreen?: boolean;
-
-  /**
    * Set a URL to a custom Spotlight Sidecar instance. The Spotlight overlay
    * will use this URL instead of the default URL to connect to the sidecar
    * and to listen to incoming events.
@@ -34,13 +24,12 @@ export type SpotlightOverlayOptions = {
   sidecarUrl?: string;
 
   /**
-   * If set to `false`, the Spotlight button will not be visible.
-   * This is useful if Spotlight is integrated into an existing UI,
-   * such as the Astro Dev Overlay.
+   * If set to `true`, the Spotlight overlay Window will be opened immediately
+   * after calling the init function.
    *
-   * @default true
+   * @default false - only the Spotlight button is visible.
    */
-  showTriggerButton?: boolean;
+  openOnInit?: boolean;
 
   /**
    * By default, Spotlight waits until the host page is loaded before injecting the
@@ -55,6 +44,15 @@ export type SpotlightOverlayOptions = {
    * @default false
    */
   injectImmediately?: boolean;
+
+  /**
+   * If set to `false`, the Spotlight button will not be visible.
+   * This is useful if Spotlight is integrated into an existing UI,
+   * such as the Astro Dev Overlay.
+   *
+   * @default true
+   */
+  showTriggerButton?: boolean;
 
   /**
    * Set this option to define where the spotlight button should be anchored.

--- a/packages/website/src/content/docs/reference/configuration.md
+++ b/packages/website/src/content/docs/reference/configuration.md
@@ -92,3 +92,10 @@ init({
   injectImmediately: true,
 });
 ```
+
+### `openOnInit`
+
+**type:** `boolean` **default:** `false`
+
+If set to `true`, the Spotlight overlay Window will be opened immediately after calling the init function. By default,
+only the button is visible.


### PR DESCRIPTION
Previously, the name was missleading, suggesting it'd make open the overlay
    in fullscreen rather than windowed mode, which it never did.
    The only thing this option does is controlling if the overlay window
    should be opened immediately when the UI is rendered or if just the
    button should be displayed.