### PR TITLE
doc(setup): Add Sveltekit Instructions

### DIFF
--- a/demos/sveltekit/src/hooks.server.ts
+++ b/demos/sveltekit/src/hooks.server.ts
@@ -4,7 +4,7 @@ import { setupSidecar } from '@spotlightjs/spotlight/sidecar';
 Sentry.init({
 	debug: true,
 	tracesSampleRate: 1.0,
-	spotlight: import.meta.env.DEV ?? false
+	spotlight: import.meta.env.DEV
 });
 
 if (import.meta.env.DEV) {

--- a/demos/sveltekit/vite.config.ts
+++ b/demos/sveltekit/vite.config.ts
@@ -1,8 +1,9 @@
+import { sentrySvelteKit } from '@sentry/sveltekit';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
-	plugins: [sveltekit()],
+	plugins: [sveltekit(), sentrySvelteKit({ autoUploadSourceMaps: false })],
 	test: {
 		include: ['src/**/*.{test,spec}.{js,ts}']
 	}

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -106,6 +106,10 @@ export default defineConfig({
               label: 'for Remix',
               link: '/setup/remix/',
             },
+            {
+              label: 'for SvelteKit',
+              link: '/setup/sveltekit/',
+            },
           ],
         },
         {

--- a/packages/website/src/components/InstallCommand.mdx
+++ b/packages/website/src/components/InstallCommand.mdx
@@ -1,0 +1,23 @@
+---
+title: Install Spotlight Codeblock
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+<Tabs>
+  <TabItem label="npm">
+  ```sh 
+  npm add @spotlightjs/spotlight
+  ```
+  </TabItem>
+  <TabItem label="pnpm">
+  ```sh 
+  pnpm add @spotlightjs/spotlight
+  ```
+  </TabItem>
+  <TabItem label="yarn">
+  ```sh 
+  yarn add @spotlightjs/spotlight
+  ```
+  </TabItem>
+</Tabs>

--- a/packages/website/src/content/docs/setup/index.mdx
+++ b/packages/website/src/content/docs/setup/index.mdx
@@ -13,6 +13,7 @@ While it's not dependent on Sentry, Spotlight is much more powerful if you're us
 
 <LinkCard title="Spotlight for Astro" description="Astro specific instructions for setting up Spotlight." href="/setup/astro/" />
 <LinkCard title="Spotlight for Remix" description="Remix specific instructions for setting up Spotlight." href="/setup/remix/" />
+<LinkCard title="Spotlight for SvelteKit" description="SvelteKit specific instructions for setting up Spotlight." href="/setup/sveltekit/" />
 
 ## Overlay
 

--- a/packages/website/src/content/docs/setup/remix.mdx
+++ b/packages/website/src/content/docs/setup/remix.mdx
@@ -1,7 +1,9 @@
 ---
 title: Using Spotlight with Remix
-description: A guide how to setup Spotlight for Astro
+description: A guide how to setup Spotlight for Remix
 ---
+
+import { Content as InstallCommand } from "../../../components/InstallCommand.mdx";
 
 ## Install Sentry & Spotlight
 
@@ -11,25 +13,7 @@ Follow the [Remix Getting Started](https://docs.sentry.io/platforms/javascript/g
 This guide is focused on Remix _without Vite_. It needs Vite added to the documentation, but the steps should be similar.
 :::
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
-
-<Tabs>
-  <TabItem label="npm">
-  ```sh 
-  npm add @spotlightjs/spotlight
-  ```
-  </TabItem>
-  <TabItem label="pnpm">
-  ```sh 
-  pnpm add @spotlightjs/spotlight
-  ```
-  </TabItem>
-  <TabItem label="yarn">
-  ```sh 
-  yarn add @spotlightjs/spotlight
-  ```
-  </TabItem>
-</Tabs>
+<InstallCommand/>
 
 Initialize Spotlight within `entry.client.js`, after you've hydrated the document:
 

--- a/packages/website/src/content/docs/setup/sveltekit.mdx
+++ b/packages/website/src/content/docs/setup/sveltekit.mdx
@@ -1,0 +1,67 @@
+---
+title: Using Spotlight with Sveltekit
+description: A guide how to setup Spotlight for Sveltekit
+---
+
+import { Content as InstallCommand } from '../../../components/InstallCommand.mdx';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+## Install Sentry 
+
+Follow the [Sveltekit Getting Started](https://docs.sentry.io/platforms/javascript/guides/sveltekit/) guide on Sentry, and continue from there.
+
+## Install Spotlight
+
+<InstallCommand/>
+
+Initialize Spotlight after Sentry and start the Sidecar on the server. Just add a little code to your [SvelteKit hooks](https://kit.svelte.dev/docs/hooks) files:
+
+<Tabs>
+
+<TabItem label="Client">
+```javascript {3, 13-17}
+// hooks.client.js
+import * as Sentry from '@sentry/sveltekit';
+import * as Spotlight from '@spotlightjs/spotlight';
+
+Sentry.init({
+  dsn: '___DSN___',
+  tracesSampleRate: 1.0,
+  // ...your Sentry options
+});
+
+export const handleError = Sentry.handleErrorWithSentry();
+
+if (import.meta.env.DEV) {
+	Spotlight.init({ 
+    injectImmediately: true, 
+  });
+}
+```
+</TabItem>
+
+<TabItem label="Server">
+```javascript {3, 9, 15-17} ins="spotlight:"
+// hooks.server.js
+import * as Sentry from '@sentry/sveltekit';
+import { setupSidecar } from '@spotlightjs/spotlight/sidecar';
+
+Sentry.init({
+  dsn: '___DSN___',
+  tracesSampleRate: 1.0,
+  // ...your Sentry options
+	spotlight: import.meta.env.DEV
+});
+
+export const handleError = Sentry.handleErrorWithSentry();
+export const handle = Sentry.sentryHandle();
+
+if (import.meta.env.DEV) {
+	setupSidecar();
+}
+```
+</TabItem>
+
+</Tabs>
+
+That's it! Check out the [Configuration](/reference/configuration/) to further customize Spotlight.


### PR DESCRIPTION
Adds Sveltekit instructions

+ refactors install command codeblock to a dedicated component
+ slightly adjusts and fixes the remix page  
