### PR TITLE
doc(setup): Use grid instead of individual link cards

### DIFF
--- a/packages/website/src/content/docs/setup/index.mdx
+++ b/packages/website/src/content/docs/setup/index.mdx
@@ -9,11 +9,13 @@ Spotlight can be used with a variety of frameworks and even in your custom envir
 
 While it's not dependent on Sentry, Spotlight is much more powerful if you're using Sentry's SDKs. It will leverage the error and traces they collect and render them locally.
 
-**Are you using one of these frameworks? Check out this guide instead:**
+**Are you using one of these frameworks? Check out these guides instead:**
 
-<LinkCard title="Spotlight for Astro" description="Astro specific instructions for setting up Spotlight." href="/setup/astro/" />
-<LinkCard title="Spotlight for Remix" description="Remix specific instructions for setting up Spotlight." href="/setup/remix/" />
-<LinkCard title="Spotlight for SvelteKit" description="SvelteKit specific instructions for setting up Spotlight." href="/setup/sveltekit/" />
+<LinkCard title="Astro" href="/setup/astro/" description="Spotlight integrates automatically with Astro's Dev Overlay" />
+<CardGrid>
+  <LinkCard title="Remix" href="/setup/remix/" />
+  <LinkCard title="Sveltekit" href="/setup/sveltekit/" />
+</CardGrid>
 
 ## Overlay
 


### PR DESCRIPTION
figured it makes sense to use a grid here because eventually this list is gonna become too long and repetetive

before:
![image](https://github.com/getsentry/spotlight/assets/8420481/56e8bb45-796e-4c72-8502-73f2080fdc53)

after:
<img width="746" alt="image" src="https://github.com/getsentry/spotlight/assets/8420481/00eae585-0a7a-496f-9965-53bfcf26fc87">
