### PR TITLE
ref(website): Adjust 30 seconds to liftoff

### DIFF
--- a/packages/website/src/components/FeatureCard.astro
+++ b/packages/website/src/components/FeatureCard.astro
@@ -1,5 +1,5 @@
 ---
-const { title, description, accentColor, reverse, linkText, linkUrl } = Astro.props;
+const { title, description, accentColor, reverse, linkText, linkUrl, imageUrl } = Astro.props;
 import { LinkCard } from '@astrojs/starlight/components';
 ---
 
@@ -68,6 +68,7 @@ import { LinkCard } from '@astrojs/starlight/components';
     <h5 class="mb-2 heading">{title}</h5>
     <p>{description}</p>
     {linkUrl && linkText ? <a href={linkUrl} class="link">{linkText}</a> : null}
+    <slot name="image"/>
   </div>
   <div class="flex-1 max-w-xl h-max" style={{margin: 0}}>
     <slot />

--- a/packages/website/src/components/LandingPage.astro
+++ b/packages/website/src/components/LandingPage.astro
@@ -27,7 +27,7 @@ import { Content as CodeBlock } from './codeblock.mdx';
     linkUrl="/setup"
     linkText="Setup"
   >
-    <CodeBlock />
+  <CodeBlock />
   </FeatureCard>
   <img class="centered lg:w-4/12 w-10/12" src="/images/simple-event-flow.png"  />
 </Section>

--- a/packages/website/src/components/LandingPage.astro
+++ b/packages/website/src/components/LandingPage.astro
@@ -27,9 +27,9 @@ import { Content as CodeBlock } from './codeblock.mdx';
     linkUrl="/setup"
     linkText="Setup"
   >
-  <CodeBlock />
+    <img slot="image" class="lg:w-8/12 w-10/12 mt-12" src="/images/simple-event-flow.png"  />
+    <CodeBlock />
   </FeatureCard>
-  <img class="centered lg:w-4/12 w-10/12" src="/images/simple-event-flow.png"  />
 </Section>
 
 

--- a/packages/website/src/components/LandingPage.astro
+++ b/packages/website/src/components/LandingPage.astro
@@ -27,8 +27,9 @@ import { Content as CodeBlock } from './codeblock.mdx';
     linkUrl="/setup"
     linkText="Setup"
   >
-    <img slot="image" class="lg:w-8/12 w-10/12 mt-12" src="/images/simple-event-flow.png"  />
+    <img slot="image" class="!hidden md:!block lg:w-8/12 mt-12 " src="/images/simple-event-flow.png"  />
     <CodeBlock />
+    <img class="md:!hidden mx-auto !mt-12 w-8/12" src="/images/simple-event-flow.png"  />
   </FeatureCard>
 </Section>
 

--- a/packages/website/src/components/LandingPage.astro
+++ b/packages/website/src/components/LandingPage.astro
@@ -27,7 +27,7 @@ import { Content as CodeBlock } from './codeblock.mdx';
     linkUrl="/setup"
     linkText="Setup"
   >
-    <img slot="image" class="!hidden md:!block lg:w-8/12 mt-12 " src="/images/simple-event-flow.png"  />
+    <img slot="image" class="!hidden md:!block lg:w-8/12 mt-12 mx-auto " src="/images/simple-event-flow.png"  />
     <CodeBlock />
     <img class="md:!hidden mx-auto !mt-12 w-8/12" src="/images/simple-event-flow.png"  />
   </FeatureCard>

--- a/packages/website/src/components/codeblock.mdx
+++ b/packages/website/src/components/codeblock.mdx
@@ -2,6 +2,10 @@
 title: Setup Codeblock
 ---
 
+```shell
+npm install @spotlightjs/spotlight
+```
+
 ```ts
 import * as Spotlight from '@spotlightjs/spotlight';
 

--- a/packages/website/src/components/codeblock.mdx
+++ b/packages/website/src/components/codeblock.mdx
@@ -2,11 +2,11 @@
 title: Setup Codeblock
 ---
 
-```shell
+```shell title="1. Install Spotlight"
 npm install @spotlightjs/spotlight
 ```
 
-```ts
+```ts title="2. Init the Overlay" frame="terminal"
 import * as Spotlight from '@spotlightjs/spotlight';
 
 if (process.env.NODE_ENV === 'development') {
@@ -14,6 +14,6 @@ if (process.env.NODE_ENV === 'development') {
 }
 ```
 
-```shell
+```shell title="3. Start the Sidecar"
 npx spotlight-sidecar
 ```


### PR DESCRIPTION
added the install command which makes the two other snippets more cohesive but also increases height. 
Appreciate opinions/feedback

before:

<img width="1125" alt="image" src="https://github.com/getsentry/spotlight/assets/8420481/8aa82755-1ef4-4996-8b38-6a6651b04d6b">

after:
<img width="1080" alt="image" src="https://github.com/getsentry/spotlight/assets/8420481/6786e22f-2202-4298-a048-bb5fd92150bb">

