### PR TITLE
feat(overlay): open/close overlay on keypress

### DIFF
--- a/packages/astro/src/overlay/index.ts
+++ b/packages/astro/src/overlay/index.ts
@@ -48,6 +48,14 @@ export default {
           }),
         );
       }, 500);
+
+      eventTarget.dispatchEvent(
+        new CustomEvent('toggle-plugin', {
+          detail: {
+            state: true,
+          },
+        }),
+      );
     });
 
     Spotlight.onSevereEvent(() => {

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -59,10 +59,18 @@ export default function App({
       setOpen(false);
     };
 
+    const handleKeyPress = (event: KeyboardEvent) => {
+      if (event && event.ctrlKey && event.shiftKey && event.key.toLowerCase() === 's') {
+        setOpen(prevValue => !prevValue);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyPress);
     spotlightEventTarget.addEventListener('open', onOpen);
     spotlightEventTarget.addEventListener('close', onClose);
 
     return () => {
+      document.removeEventListener('keydown', handleKeyPress);
       spotlightEventTarget.removeEventListener('open', onOpen);
       spotlightEventTarget.removeEventListener('close', onClose);
     };

--- a/packages/overlay/src/components/Trigger.tsx
+++ b/packages/overlay/src/components/Trigger.tsx
@@ -76,6 +76,7 @@ export default function Trigger({
         getAnchorClasses(anchor),
         isOpen ? '!hidden' : '',
       )}
+      title="Spotlight by Sentry"
       onClick={() => setOpen(!isOpen)}
     >
       <ToolbarItem count={countSum} severe={Boolean(notificationCount.severe)}>


### PR DESCRIPTION
#158 

Added an event listener for opening/closing overlay using `Ctrl + Shift + s`
Also made this to astro dev as well.