### PR TITLE
fix(overlay): Close Overlay on ESC press in all frameworks

### DIFF
--- a/packages/overlay/src/components/Debugger.tsx
+++ b/packages/overlay/src/components/Debugger.tsx
@@ -81,6 +81,7 @@ export default function Debugger({
           integrations={integrations}
           integrationData={integrationData}
           setTriggerButtonCount={setNotificationCount}
+          setOpen={setOpen}
         />
       </div>
     </div>

--- a/packages/overlay/src/components/Overview.tsx
+++ b/packages/overlay/src/components/Overview.tsx
@@ -8,10 +8,12 @@ export default function Overview({
   integrations,
   integrationData,
   setTriggerButtonCount,
+  setOpen,
 }: {
   integrations: Integration[];
   integrationData: IntegrationData<unknown>;
   setTriggerButtonCount: (count: NotificationCount) => void;
+  setOpen: (value: boolean) => void;
 }) {
   const [notificationCountSum, setNotificationCountSum] = useState<NotificationCount>({ count: 0, severe: false });
 
@@ -49,7 +51,7 @@ export default function Overview({
   return (
     <>
       <MemoryRouter initialEntries={[initialTab]}>
-        <Tabs tabs={tabs} />
+        <Tabs tabs={tabs} setOpen={setOpen} />
         <Routes>
           <Route path="/not-found" element={<p>Not Found - How'd you manage to get here?</p>} key={'not-found'}></Route>
           {tabs.map(tab => {

--- a/packages/overlay/src/components/Tabs.tsx
+++ b/packages/overlay/src/components/Tabs.tsx
@@ -1,7 +1,6 @@
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { type IntegrationTab } from '~/integrations/integration';
 import classNames from '../lib/classNames';
-import { getSpotlightEventTarget } from '../lib/eventTarget';
 import useKeyPress from '../lib/useKeyPress';
 
 export type Props = {
@@ -9,23 +8,35 @@ export type Props = {
    * Array of tabs to display.
    */
   tabs: IntegrationTab<unknown>[];
+} & (NestedTabsProps | TopLevelTabsProps);
 
+type NestedTabsProps = {
   /**
    * Whether the tabs are nested inside another tab.
    * If `nested` is `true`, links will be set relative to the parent
    * tab route instead of absolute to the root.
    */
-  nested?: boolean;
+  nested: true;
+
+  setOpen?: undefined;
 };
 
-export default function Tabs({ tabs, nested }: Props) {
+type TopLevelTabsProps = {
+  nested?: false;
+
+  /**
+   * Setter to control the open state of the overlay
+   */
+  setOpen: (value: boolean) => void;
+};
+
+export default function Tabs({ tabs, nested, setOpen }: Props) {
   const navigate = useNavigate();
   const location = useLocation();
-  const spotlightEventTarget = getSpotlightEventTarget();
 
   useKeyPress('Escape', () => {
-    if (location.pathname.split('/').length === 2) {
-      spotlightEventTarget.dispatchEvent(new CustomEvent('closed'));
+    if (setOpen && location.pathname.split('/').length === 2) {
+      setOpen(false);
     } else {
       navigate(-1);
     }


### PR DESCRIPTION
Previously, we emitted the wrong eventTarget event: `closed` instead of `close`. (I can see how these names were probably not optimal 
lol). This PR now fixes the ESC closing behaviour by simply calling the `setOpen(false)` state setter instead of emitting any events. 
IMO we should avoid using the event target within the Overlay UI where we can work with state setters.
