### PR TITLE
feat(overlay): Add tags to error event contexts view

### DIFF
--- a/.changeset/strange-lions-swim.md
+++ b/.changeset/strange-lions-swim.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+feat(overlay): Add tags to error event contexts view

--- a/packages/overlay/src/integrations/sentry/components/EventContexts.tsx
+++ b/packages/overlay/src/integrations/sentry/components/EventContexts.tsx
@@ -1,4 +1,5 @@
 import { SentryEvent } from '../types';
+import Tags from './Tags';
 
 const EXAMPLE_CONTEXT = `Sentry.setContext("character", {
   name: "Mighty Fighter",
@@ -8,7 +9,10 @@ const EXAMPLE_CONTEXT = `Sentry.setContext("character", {
 
 export default function EventContexts({ event }: { event: SentryEvent }) {
   const contexts = { extra: event.extra, ...event.contexts };
-  if (!contexts || !Object.values(contexts).find(v => !!v)) {
+
+  const tags = event.tags;
+
+  if ((!contexts || !Object.values(contexts).find(v => !!v)) && !tags) {
     return (
       <div className="space-y-4 px-6">
         <div className="text-primary-300">
@@ -19,33 +23,41 @@ export default function EventContexts({ event }: { event: SentryEvent }) {
     );
   }
   return (
-    <div className="space-y-6">
-      {Object.entries(contexts).map(([ctxKey, ctxValues]) => {
-        if (!ctxValues) return null;
-        return (
-          <div key={ctxKey}>
-            <h2 className="font-bold uppercase">{ctxKey}</h2>
-            <table className="w-full">
-              <tbody>
-                {Object.entries(ctxValues).map(([key, value]) => {
-                  return (
-                    <tr key={key}>
-                      <th className="text-primary-300 w-1/12 py-0.5 pr-4 text-left font-mono font-normal">
-                        <div className="w-full truncate">{key}</div>
-                      </th>
-                      <td className="py-0.5">
-                        <pre className="text-primary-300 whitespace-nowrap font-mono">
-                          {JSON.stringify(value, undefined, 2)}
-                        </pre>
-                      </td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
-        );
-      })}
-    </div>
+    <>
+      {tags && (
+        <div className="pb-4">
+          <h2 className="font-bold uppercase">Tags</h2>
+          <Tags tags={tags} />
+        </div>
+      )}
+      <div className="space-y-6">
+        {Object.entries(contexts).map(([ctxKey, ctxValues]) => {
+          if (!ctxValues) return null;
+          return (
+            <div key={ctxKey}>
+              <h2 className="font-bold uppercase">{ctxKey}</h2>
+              <table className="w-full">
+                <tbody>
+                  {Object.entries(ctxValues).map(([key, value]) => {
+                    return (
+                      <tr key={key}>
+                        <th className="text-primary-300 w-1/12 py-0.5 pr-4 text-left font-mono font-normal">
+                          <div className="w-full truncate">{key}</div>
+                        </th>
+                        <td className="py-0.5">
+                          <pre className="text-primary-300 whitespace-nowrap font-mono">
+                            {JSON.stringify(value, undefined, 2)}
+                          </pre>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          );
+        })}
+      </div>
+    </>
   );
 }

--- a/packages/overlay/src/integrations/sentry/components/Tags.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Tags.tsx
@@ -1,0 +1,22 @@
+export default function Tags({ tags }: { tags: { [key: string]: string } }) {
+  return (
+    <div className="flex flex-row flex-wrap gap-2">
+      {Object.keys(tags).map(tagKey => {
+        return <Tag key={tagKey} tagKey={tagKey} value={tags[tagKey]}></Tag>;
+      })}
+    </div>
+  );
+}
+
+function Tag({ tagKey, value }: { tagKey: string; value: string }) {
+  return (
+    <div className="mt-2 whitespace-nowrap text-sm">
+      <span className="bg-primary-900 border-primary-300 h-[30px] rounded-l-full border-[1px] p-1 pl-2 font-semibold ">
+        {tagKey}
+      </span>
+      <span className=" border-primary-300 h-[30px] rounded-r-full border-[1px] border-l-0 p-1 pr-2 align-bottom font-mono">
+        {value}
+      </span>
+    </div>
+  );
+}

--- a/packages/overlay/src/integrations/sentry/components/Tags.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Tags.tsx
@@ -1,6 +1,6 @@
 export default function Tags({ tags }: { tags: { [key: string]: string } }) {
   return (
-    <div className="flex flex-row flex-wrap gap-2">
+    <div className="flex flex-row flex-wrap gap-2 pt-2">
       {Object.keys(tags).map(tagKey => {
         return <Tag key={tagKey} tagKey={tagKey} value={tags[tagKey]}></Tag>;
       })}
@@ -10,13 +10,9 @@ export default function Tags({ tags }: { tags: { [key: string]: string } }) {
 
 function Tag({ tagKey, value }: { tagKey: string; value: string }) {
   return (
-    <div className="mt-2 whitespace-nowrap text-sm">
-      <span className="bg-primary-900 border-primary-300 h-[30px] rounded-l-full border-[1px] p-1 pl-2 font-semibold ">
-        {tagKey}
-      </span>
-      <span className=" border-primary-300 h-[30px] rounded-r-full border-[1px] border-l-0 p-1 pr-2 align-bottom font-mono">
-        {value}
-      </span>
+    <div className="border-primary-300 bg-primary-900 divide-x-primary-300 inline-flex divide-x whitespace-nowrap rounded-full border font-mono text-sm">
+      <div className="px-2 py-1 font-semibold">{tagKey}</div>
+      <div className="bg-primary-800 rounded-r-full px-2 py-1">{value}</div>
     </div>
   );
 }


### PR DESCRIPTION
Current state, appreciate input or feel free to take over

<img width="1005" alt="image" src="https://github.com/getsentry/spotlight/assets/8420481/24a61118-d161-4f76-9504-e66f305a0aa7">

closes #177 