### PR TITLE
chore: Bump Sentry SDKs to 7.85.0

### DIFF
--- a/demos/astro-playground/package.json
+++ b/demos/astro-playground/package.json
@@ -17,7 +17,7 @@
     "@astrojs/node": "^6.0.4",
     "@astrojs/react": "^3.0.5",
     "@astrojs/svelte": "^4.0.4",
-    "@sentry/astro": "^7.83.0",
+    "@sentry/astro": "^7.85.0",
     "@spotlightjs/astro": "workspace:*",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/demos/sveltekit/package.json
+++ b/demos/sveltekit/package.json
@@ -13,7 +13,7 @@
 		"clean": "rimraf .svelte-kit"
 	},
 	"dependencies": {
-		"@sentry/sveltekit": "^7.83.0",
+		"@sentry/sveltekit": "^7.85.0",
 		"@spotlightjs/spotlight": "workspace:*"
 	},
 	"devDependencies": {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -19,7 +19,7 @@
     "@astrojs/tailwind": "^5.0.2",
     "@astrojs/vercel": "^5.2.0",
     "@fontsource/raleway": "^5.0.15",
-    "@sentry/astro": "^7.83.0",
+    "@sentry/astro": "^7.85.0",
     "@spotlightjs/astro": "workspace:*",
     "@spotlightjs/overlay": "workspace:*",
     "@types/react": "^18.2.38",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(astro@3.5.5)(svelte@5.0.0-next.4)(typescript@5.2.2)(vite@4.5.0)
       '@sentry/astro':
-        specifier: ^7.83.0
-        version: 7.83.0(astro@3.5.5)
+        specifier: ^7.85.0
+        version: 7.85.0(astro@3.5.5)
       '@spotlightjs/astro':
         specifier: workspace:*
         version: link:../../packages/astro
@@ -98,8 +98,8 @@ importers:
   demos/sveltekit:
     dependencies:
       '@sentry/sveltekit':
-        specifier: ^7.83.0
-        version: 7.83.0(@sveltejs/kit@1.27.6)(svelte@4.2.7)
+        specifier: ^7.85.0
+        version: 7.85.0(@sveltejs/kit@1.27.6)(svelte@4.2.7)
       '@spotlightjs/spotlight':
         specifier: workspace:*
         version: link:../../packages/spotlight
@@ -334,8 +334,8 @@ importers:
         specifier: ^5.0.15
         version: 5.0.15
       '@sentry/astro':
-        specifier: ^7.83.0
-        version: 7.83.0(astro@3.6.0)
+        specifier: ^7.85.0
+        version: 7.85.0(astro@3.6.0)
       '@spotlightjs/astro':
         specifier: workspace:*
         version: link:../astro
@@ -2547,6 +2547,16 @@ packages:
       string-argv: 0.3.2
     dev: true
 
+  /@sentry-internal/feedback@7.85.0:
+    resolution:
+      { integrity: sha512-MlbIN+N8CWFJBjbqMmARe4+UPo9QRhRar0YoOfmNA2Xqk/EwXcjHWkealosHznXH7tqVbjB25QJpHtDystft/Q== }
+    engines: { node: '>=12' }
+    dependencies:
+      '@sentry/core': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+    dev: false
+
   /@sentry-internal/tracing@7.83.0:
     resolution:
       { integrity: sha512-fY1ZyOiQaaUTuoq5rO+G4/5Ov3n8BnfNK7ck97yAGxy3w+E1CwhVZkXHEvTngNfdYV3ArxvlrtPRb9STFRqXvQ== }
@@ -2567,42 +2577,14 @@ packages:
       '@sentry/utils': 7.84.0
     dev: false
 
-  /@sentry/astro@7.83.0(astro@3.5.5):
+  /@sentry-internal/tracing@7.85.0:
     resolution:
-      { integrity: sha512-PWGFPUYbznEAnAA6ZTgAQs7DAvrqSaoAM/uDzgWiL3e3TVUezDGGvnDf2BmM9p5LpRyDLur4becn2jhtapDLoQ== }
-    engines: { node: '>=18.14.1' }
-    peerDependencies:
-      astro: '>=3.x'
+      { integrity: sha512-p3YMUwkPCy2su9cm/3+7QYR4RiMI0+07DU1BZtht9NLTzY2O87/yvUbn1v2yHR3vJQTy/+7N0ud9/mPBFznRQQ== }
+    engines: { node: '>=8' }
     dependencies:
-      '@sentry/browser': 7.83.0
-      '@sentry/core': 7.83.0
-      '@sentry/node': 7.83.0
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
-      '@sentry/vite-plugin': 2.10.1
-      astro: 3.5.5(typescript@5.2.2)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
-    dev: false
-
-  /@sentry/astro@7.83.0(astro@3.6.0):
-    resolution:
-      { integrity: sha512-PWGFPUYbznEAnAA6ZTgAQs7DAvrqSaoAM/uDzgWiL3e3TVUezDGGvnDf2BmM9p5LpRyDLur4becn2jhtapDLoQ== }
-    engines: { node: '>=18.14.1' }
-    peerDependencies:
-      astro: '>=3.x'
-    dependencies:
-      '@sentry/browser': 7.83.0
-      '@sentry/core': 7.83.0
-      '@sentry/node': 7.83.0
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
-      '@sentry/vite-plugin': 2.10.1
-      astro: 3.6.0(typescript@5.3.2)
-    transitivePeerDependencies:
-      - encoding
-      - supports-color
+      '@sentry/core': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
     dev: false
 
   /@sentry/astro@7.84.0(astro@4.0.0-beta.4):
@@ -2624,16 +2606,42 @@ packages:
       - supports-color
     dev: false
 
-  /@sentry/browser@7.83.0:
+  /@sentry/astro@7.85.0(astro@3.5.5):
     resolution:
-      { integrity: sha512-8v7QEaC/fVAHn8pi59ZlJznr7ZdOQIgtz8DAOJeJsC2vHTAxQ9nVkoMkJWjTp/qaDHUjSe5ob6eqaChuhi6t2g== }
-    engines: { node: '>=8' }
+      { integrity: sha512-wGVYkYQ5Nk3W+44oc8rv/aBW3uXUgXUF8quEyMrROVLAAbC03qhI11oTFpDSgyulk7X3gSyqpvRGadxA4r9e4g== }
+    engines: { node: '>=18.14.1' }
+    peerDependencies:
+      astro: '>=3.x || >=4.0.0-beta'
     dependencies:
-      '@sentry-internal/tracing': 7.83.0
-      '@sentry/core': 7.83.0
-      '@sentry/replay': 7.83.0
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
+      '@sentry/browser': 7.85.0
+      '@sentry/core': 7.85.0
+      '@sentry/node': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+      '@sentry/vite-plugin': 2.10.1
+      astro: 3.5.5(typescript@5.2.2)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: false
+
+  /@sentry/astro@7.85.0(astro@3.6.0):
+    resolution:
+      { integrity: sha512-wGVYkYQ5Nk3W+44oc8rv/aBW3uXUgXUF8quEyMrROVLAAbC03qhI11oTFpDSgyulk7X3gSyqpvRGadxA4r9e4g== }
+    engines: { node: '>=18.14.1' }
+    peerDependencies:
+      astro: '>=3.x || >=4.0.0-beta'
+    dependencies:
+      '@sentry/browser': 7.85.0
+      '@sentry/core': 7.85.0
+      '@sentry/node': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+      '@sentry/vite-plugin': 2.10.1
+      astro: 3.6.0(typescript@5.3.2)
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
     dev: false
 
   /@sentry/browser@7.84.0:
@@ -2648,13 +2656,26 @@ packages:
       '@sentry/utils': 7.84.0
     dev: false
 
+  /@sentry/browser@7.85.0:
+    resolution:
+      { integrity: sha512-x4sH7vTQnZQgy1U7NuN8XwhleAw7YMQitccHeC5m+kpIKGUO7w4Mdvu8rD3dnjmVmZvASpnwocAxy57/vCU6Ww== }
+    engines: { node: '>=8' }
+    dependencies:
+      '@sentry-internal/feedback': 7.85.0
+      '@sentry-internal/tracing': 7.85.0
+      '@sentry/core': 7.85.0
+      '@sentry/replay': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+    dev: false
+
   /@sentry/bundler-plugin-core@0.6.1:
     resolution:
       { integrity: sha512-EecCJKp9ERM7J93DNDJTvkY78UiD/IfOjBdXWnaUVE0n619O7LfMVjwlXzxRJKl2x05dBE3lDraILLDGxCf6fg== }
     engines: { node: '>= 10' }
     dependencies:
       '@sentry/cli': 2.21.5
-      '@sentry/node': 7.83.0
+      '@sentry/node': 7.85.0
       '@sentry/tracing': 7.83.0
       find-up: 5.0.0
       glob: 9.3.2
@@ -2719,14 +2740,23 @@ packages:
       '@sentry/utils': 7.84.0
     dev: false
 
-  /@sentry/integrations@7.83.0:
+  /@sentry/core@7.85.0:
     resolution:
-      { integrity: sha512-KyptWUyg/Z+3qN1dBDDVcNNUzIwWpCO3mfiToV20LSeA+e/NS4IWTtsZKo2mqvoQQ/4QKcrMj7NbF5iOjKckaQ== }
+      { integrity: sha512-DFDAc4tWmHN5IWhr7XbHCiyF1Xgb95jz8Uj/JTX9atlgodId1UIbER77qpEmH3eQGid/QBdqrlR98zCixgSbwg== }
     engines: { node: '>=8' }
     dependencies:
-      '@sentry/core': 7.83.0
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+    dev: false
+
+  /@sentry/integrations@7.85.0:
+    resolution:
+      { integrity: sha512-c/uEhrFbAefK00cnm/SjqZ31rWVsruiQWAvV4dxU/rSQ2dBWDuJz1woXX7Wd03yCSMq14tXtiDy9aTC4xCZ71w== }
+    engines: { node: '>=8' }
+    dependencies:
+      '@sentry/core': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
       localforage: 1.10.0
     dev: false
 
@@ -2758,15 +2788,18 @@ packages:
       - supports-color
     dev: false
 
-  /@sentry/replay@7.83.0:
+  /@sentry/node@7.85.0:
     resolution:
-      { integrity: sha512-B/rzmjmQ3ZWE68m4Z9rHIN3Fa/wkfVVTK+iSQtqErFflyMETMNwtWRNd6P9FhXnphEINZEbcn/UZF5w5xu/DfA== }
-    engines: { node: '>=12' }
+      { integrity: sha512-uiBtRW9G017NHoCXBlK3ttkTwHXLFyI8ndHpaObtyajKTv3ptGIThVEn7DuK7Pwor//RjwjSEEOa7WDK+FdMVQ== }
+    engines: { node: '>=8' }
     dependencies:
-      '@sentry-internal/tracing': 7.83.0
-      '@sentry/core': 7.83.0
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
+      '@sentry-internal/tracing': 7.85.0
+      '@sentry/core': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+      https-proxy-agent: 5.0.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@sentry/replay@7.84.0:
@@ -2780,34 +2813,45 @@ packages:
       '@sentry/utils': 7.84.0
     dev: false
 
-  /@sentry/svelte@7.83.0(svelte@4.2.7):
+  /@sentry/replay@7.85.0:
     resolution:
-      { integrity: sha512-FKopMiYT23aZJbRIRyvR91/gIaI6BpEJp+3HXWs33HX9Mus7X9Ah1DoPAIfAxLa8YCAATQcrJ7Cnx8Gk4mbxcA== }
+      { integrity: sha512-zVtTKfO+lu5qTwHpETI/oGo8hU3rdKHr3CdI1vRLw+d60PcAa/pWVlXsQeLRTw8PFwE358gHcpFZezj/11afew== }
+    engines: { node: '>=12' }
+    dependencies:
+      '@sentry-internal/tracing': 7.85.0
+      '@sentry/core': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
+    dev: false
+
+  /@sentry/svelte@7.85.0(svelte@4.2.7):
+    resolution:
+      { integrity: sha512-XKXMpNJJ2GShl08kQvw8G4/aq2zaSpBkNEK3JNN6jAcLfMdHqbc8DSRFiDXdZt8udEa/4s3RqUOj/nApckmi0A== }
     engines: { node: '>=8' }
     peerDependencies:
       svelte: 3.x || 4.x
     dependencies:
-      '@sentry/browser': 7.83.0
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
+      '@sentry/browser': 7.85.0
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
       magic-string: 0.30.5
       svelte: 4.2.7
     dev: false
 
-  /@sentry/sveltekit@7.83.0(@sveltejs/kit@1.27.6)(svelte@4.2.7):
+  /@sentry/sveltekit@7.85.0(@sveltejs/kit@1.27.6)(svelte@4.2.7):
     resolution:
-      { integrity: sha512-yTQOF+bU6V0wSGsdbLEo4tYimkFEmyKyBp6H4zN6zIEKneEuJfQen7IiyoPilrWk86QqHchW3JNFLgk01qrvrw== }
+      { integrity: sha512-EqNsNeFQPNFnKYQAWdb62MfwKnE8xA1hjRomWZfhj7nyysAjRxREUoiyvsGU2s+gdW5nIt0ocAn5dEfwomggSg== }
     engines: { node: '>=16' }
     peerDependencies:
       '@sveltejs/kit': 1.x
     dependencies:
-      '@sentry-internal/tracing': 7.83.0
-      '@sentry/core': 7.83.0
-      '@sentry/integrations': 7.83.0
-      '@sentry/node': 7.83.0
-      '@sentry/svelte': 7.83.0(svelte@4.2.7)
-      '@sentry/types': 7.83.0
-      '@sentry/utils': 7.83.0
+      '@sentry-internal/tracing': 7.85.0
+      '@sentry/core': 7.85.0
+      '@sentry/integrations': 7.85.0
+      '@sentry/node': 7.85.0
+      '@sentry/svelte': 7.85.0(svelte@4.2.7)
+      '@sentry/types': 7.85.0
+      '@sentry/utils': 7.85.0
       '@sentry/vite-plugin': 0.6.1
       '@sveltejs/kit': 1.27.6(svelte@4.2.7)(vite@4.5.0)
       magicast: 0.2.8
@@ -2844,6 +2888,12 @@ packages:
     engines: { node: '>=8' }
     dev: false
 
+  /@sentry/types@7.85.0:
+    resolution:
+      { integrity: sha512-R5jR4XkK5tBU2jDiPdSVqzkmjYRr666bcGaFGUHB/xDQCjPsjk+pEmCCL+vpuWoaZmQJUE1hVU7rgnVX81w8zg== }
+    engines: { node: '>=8' }
+    dev: false
+
   /@sentry/utils@7.81.1:
     resolution:
       { integrity: sha512-gq+MDXIirHKxNZ+c9/lVvCXd6y2zaZANujwlFggRH2u9SRiPaIXVilLpvMm4uJqmqBMEcY81ArujExtHvkbCqg== }
@@ -2866,6 +2916,14 @@ packages:
     engines: { node: '>=8' }
     dependencies:
       '@sentry/types': 7.84.0
+    dev: false
+
+  /@sentry/utils@7.85.0:
+    resolution:
+      { integrity: sha512-JZ7seNOLvhjAQ8GeB3GYknPQJkuhF88xAYOaESZP3xPOWBMFUN+IO4RqjMqMLFDniOwsVQS7GB/MfP+hxufieg== }
+    engines: { node: '>=8' }
+    dependencies:
+      '@sentry/types': 7.85.0
     dev: false
 
   /@sentry/vite-plugin@0.6.1:


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [ ] I referenced issues that this PR addresses
