### PR TITLE
fix(overlay): Open overlay on Ctrl+F12 instead of Ctrl/Cmd+Shift+F12

### DIFF
--- a/.changeset/cold-icons-accept.md
+++ b/.changeset/cold-icons-accept.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+fix(overlay): Open overlay on Ctrl+F12 instead of Ctrl/Cmd+Shift+F12

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -26,11 +26,7 @@ export default function App({
   const [triggerButtonCount, setTriggerButtonCount] = useState<NotificationCount>({ count: 0, severe: false });
   const [isOpen, setOpen] = useState(openOnInit);
 
-  useKeyPress(['ctrlKey', 'shiftKey', 's'], () => {
-    setOpen(prev => !prev);
-  });
-
-  useKeyPress(['metaKey', 'shiftKey', 's'], () => {
+  useKeyPress(['ctrlKey', 'F12'], () => {
     setOpen(prev => !prev);
   });
 

--- a/packages/overlay/src/lib/useKeyPress.ts
+++ b/packages/overlay/src/lib/useKeyPress.ts
@@ -9,11 +9,15 @@ import { useEffect } from 'react';
 export default function useKeyPress(keys: string[], action: () => void, propagate = false) {
   useEffect(() => {
     function onKeyup(e: KeyboardEvent) {
-      if (!propagate) e.stopPropagation();
+      if (!propagate) {
+        e.stopPropagation();
+      }
 
       if (
         keys.every((key: string) => {
-          if (key in e) return e[key as keyof KeyboardEvent];
+          if (key in e) {
+            return e[key as keyof KeyboardEvent];
+          }
           return e.key.toLowerCase() === key.toLowerCase();
         })
       ) {
@@ -23,6 +27,8 @@ export default function useKeyPress(keys: string[], action: () => void, propagat
 
     window.addEventListener('keyup', onKeyup);
 
-    return () => window.removeEventListener('keyup', onKeyup);
+    return () => {
+      window.removeEventListener('keyup', onKeyup);
+    };
   }, [keys, action, propagate]);
 }


### PR DESCRIPTION
closes #218

For now we ignore the MacOS Command key as it requires more modifications to our keypress handler

<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [x] I referenced issues that this PR addresses
