### PR TITLE
feat: Dependency-inject custom logger into sidecar

### DIFF
--- a/.changeset/brown-wasps-boil.md
+++ b/.changeset/brown-wasps-boil.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+feat(astro): Use Astro integration logger instead of default logger

--- a/.changeset/late-lobsters-shave.md
+++ b/.changeset/late-lobsters-shave.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/sidecar': patch
+---
+
+feat(sidecar): Accept options object in `setupSidecar`

--- a/.changeset/lovely-moles-camp.md
+++ b/.changeset/lovely-moles-camp.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/sidecar': patch
+---
+
+feat(sidecar): Inject optional custom logger

--- a/.changeset/poor-coins-sip.md
+++ b/.changeset/poor-coins-sip.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': patch
+---
+
+ref(spotlight): Adjust `setupSidecar` call to pass port in options object

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -78,16 +78,18 @@ const createPlugin = (options?: SpotlightAstroIntegrationOptions): AstroIntegrat
         }
       },
 
-      'astro:server:start': async () => {
+      'astro:server:start': async ({ logger }) => {
         if (options?.sidecarUrl) {
+          logger.debug('Detected custom sidecar URL. Skipping default sidecar setup.');
           // If users set a custom sidecar URL, we assume they started the sidecar manually outside of Astro.
           // So we don't setup the default sidecar instance.
           return;
         }
+
         // Importing this dynamically because for some reason, the top level import
         // caused a dev server error because the sidecar code was bundled into the server
         const { setupSidecar } = await import('@spotlightjs/sidecar');
-        setupSidecar();
+        setupSidecar({ logger });
       },
     },
   };

--- a/packages/sidecar/server.js
+++ b/packages/sidecar/server.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 const { setupSidecar } = await import('./dist/main.js');
 const port = process.argv[2];
-setupSidecar(port);
+setupSidecar({ port });

--- a/packages/sidecar/src/logger.ts
+++ b/packages/sidecar/src/logger.ts
@@ -1,0 +1,26 @@
+export type SidecarLogger = {
+  info: (message: string) => void;
+  warn: (message: string) => void;
+  error: (message: string) => void;
+  debug: (message: string) => void;
+};
+
+const defaultLogger: SidecarLogger = {
+  info: (message: string) => console.log(message),
+  warn: (message: string) => console.warn(message),
+  error: (message: string) => console.error(message),
+  debug: (message: string) => console.debug(message),
+};
+
+let injectedLogger: SidecarLogger | undefined = undefined;
+
+export function activateLogger(logger: SidecarLogger): void {
+  injectedLogger = logger;
+}
+
+export const logger = {
+  info: (message: string) => (injectedLogger || defaultLogger).info(message),
+  warn: (message: string) => (injectedLogger || defaultLogger).warn(message),
+  error: (message: string) => (injectedLogger || defaultLogger).error(message),
+  debug: (message: string) => (injectedLogger || defaultLogger).debug(message),
+};

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -1,87 +1,28 @@
 import { createWriteStream } from 'fs';
 import { IncomingMessage, Server, ServerResponse, createServer } from 'http';
-import kleur from 'kleur';
 import { createGunzip, createInflate } from 'zlib';
+import { SidecarLogger, activateLogger, logger } from './logger.js';
+import { MessageBuffer } from './messageBuffer.js';
 
-function generateUuidv4(): string {
-  let dt = new Date().getTime();
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-    let rnd = Math.random() * 16;
-    rnd = (dt + rnd) % 16 | 0;
-    dt = Math.floor(dt / 16);
-    return (c === 'x' ? rnd : (rnd & 0x3) | 0x8).toString(16);
-  });
-}
-
-class MessageBuffer<T> {
-  private size: number;
-  private items: [number, T][];
-  private writePos = 0;
-  private head = 0;
-  private timeout = 10;
-  private readers = new Map<string, (item: T) => void>();
-  private timeoutId: NodeJS.Timeout | undefined;
-
-  constructor(size = 100) {
-    this.size = size;
-    this.items = new Array(size);
-  }
-
-  put(item: T): void {
-    const curTime = new Date().getTime();
-    this.items[this.writePos % this.size] = [curTime, item];
-    this.writePos += 1;
-    if (this.head === this.writePos) {
-      this.head += 1;
-    }
-
-    const minTime = curTime - this.timeout * 1000;
-    let atItem;
-    while (this.head < this.writePos) {
-      atItem = this.items[this.head % this.size];
-      if (atItem === undefined) break;
-      if (atItem[0] > minTime) break;
-      this.head += 1;
-    }
-  }
-
-  subscribe(callback: (item: T) => void): string {
-    const readerId = generateUuidv4();
-    this.readers.set(readerId, callback);
-    clearTimeout(this.timeoutId);
-    this.timeoutId = setTimeout(() => this.stream(readerId));
-    return readerId;
-  }
-
-  unsubscribe(readerId: string): void {
-    this.readers.delete(readerId);
-    clearTimeout(this.timeoutId);
-  }
-
-  stream(readerId: string, readPos = this.head): void {
-    clearTimeout(this.timeoutId);
-
-    const cb = this.readers.get(readerId);
-    if (!cb) return;
-
-    let atReadPos = readPos;
-    let item;
-    /* eslint-disable no-constant-condition */
-    while (true) {
-      item = this.items[atReadPos % this.size];
-      // atReadPos >= this.writePos prevents the case where we have a full buffer
-      if (typeof item === 'undefined' || atReadPos >= this.writePos) {
-        break;
-      }
-      cb(item[1]);
-      atReadPos += 1;
-    }
-
-    this.timeoutId = setTimeout(() => this.stream(readerId, atReadPos), 500);
-  }
-}
+const DEFAULT_PORT = 8969;
 
 type Payload = [string, string];
+
+type SideCarOptions = {
+  /**
+   * The port on which the sidecar should listen.
+   * Defaults to 8969.
+   */
+  port?: string | number;
+
+  /**
+   * A logger that implements the SidecarLogger interface.
+   * Use this to inject your custom logger implementation.
+   *
+   * @default - a simple logger logging to the console.
+   */
+  logger?: SidecarLogger;
+};
 
 function getCorsHeader(): { [name: string]: string } {
   return {
@@ -103,7 +44,7 @@ function handleStreamRequest(req: IncomingMessage, res: ServerResponse, buffer: 
       res.flushHeaders();
 
       const sub = buffer.subscribe(([payloadType, data]) => {
-        log(`🕊️ sending to Spotlight`);
+        logger.debug(`🕊️ sending to Spotlight`);
         res.write(`event:${payloadType}\n`);
         // This is very important - SSE events are delimited by two newlines
         data.split('\n').forEach(line => {
@@ -129,7 +70,7 @@ function handleStreamRequest(req: IncomingMessage, res: ServerResponse, buffer: 
         });
         res.end();
       } else if (req.method === 'POST') {
-        log(`📩 Received event`);
+        logger.debug(`📩 Received event`);
         let body: string = '';
         let stream = req;
 
@@ -160,7 +101,7 @@ function handleStreamRequest(req: IncomingMessage, res: ServerResponse, buffer: 
             const filename = `${contentType.replace(/[^a-z0-9]/gi, '_').toLowerCase()}-${timestamp}.txt`;
 
             createWriteStream(filename).write(body);
-            log(`🗃️ Saved data to ${filename}`);
+            logger.info(`🗃️ Saved data to ${filename}`);
           }
 
           res.writeHead(204, {
@@ -192,15 +133,10 @@ function startServer(buffer: MessageBuffer<Payload>, port: number): Server {
     }
   });
   server.listen(port, () => {
-    log(`Sidecar listening on ${port}`);
+    logger.info(`Sidecar listening on ${port}`);
   });
 
   return server;
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function log(...args: any[]) {
-  console.log(kleur.bold(kleur.magenta('🔎 [Spotlight]')), ...args);
 }
 
 let serverInstance: Server;
@@ -213,11 +149,15 @@ const isValidPort = (value: string | number) => {
   return value > 0 && value <= 65535;
 };
 
-export function setupSidecar(port?: string | number): void {
-  let sidecarPort = 8969;
+export function setupSidecar({ port, logger: customLogger }: SideCarOptions = {}): void {
+  let sidecarPort = DEFAULT_PORT;
+
+  if (customLogger) {
+    activateLogger(customLogger);
+  }
 
   if (port && !isValidPort(port)) {
-    log('Please provide a valid port.');
+    logger.info('Please provide a valid port.');
     process.exit(1);
   } else if (port) {
     sidecarPort = typeof port === 'string' ? parseInt(port, 10) : port;
@@ -232,7 +172,7 @@ export function setupSidecar(port?: string | number): void {
 
 function shutdown() {
   if (serverInstance) {
-    log('Shutting down server');
+    logger.info('Shutting down Server');
     serverInstance.close();
   }
 }

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -1,0 +1,77 @@
+export class MessageBuffer<T> {
+  private size: number;
+  private items: [number, T][];
+  private writePos = 0;
+  private head = 0;
+  private timeout = 10;
+  private readers = new Map<string, (item: T) => void>();
+  private timeoutId: NodeJS.Timeout | undefined;
+
+  constructor(size = 100) {
+    this.size = size;
+    this.items = new Array(size);
+  }
+
+  put(item: T): void {
+    const curTime = new Date().getTime();
+    this.items[this.writePos % this.size] = [curTime, item];
+    this.writePos += 1;
+    if (this.head === this.writePos) {
+      this.head += 1;
+    }
+
+    const minTime = curTime - this.timeout * 1000;
+    let atItem;
+    while (this.head < this.writePos) {
+      atItem = this.items[this.head % this.size];
+      if (atItem === undefined) break;
+      if (atItem[0] > minTime) break;
+      this.head += 1;
+    }
+  }
+
+  subscribe(callback: (item: T) => void): string {
+    const readerId = generateUuidv4();
+    this.readers.set(readerId, callback);
+    clearTimeout(this.timeoutId);
+    this.timeoutId = setTimeout(() => this.stream(readerId));
+    return readerId;
+  }
+
+  unsubscribe(readerId: string): void {
+    this.readers.delete(readerId);
+    clearTimeout(this.timeoutId);
+  }
+
+  stream(readerId: string, readPos = this.head): void {
+    clearTimeout(this.timeoutId);
+
+    const cb = this.readers.get(readerId);
+    if (!cb) return;
+
+    let atReadPos = readPos;
+    let item;
+    /* eslint-disable no-constant-condition */
+    while (true) {
+      item = this.items[atReadPos % this.size];
+      // atReadPos >= this.writePos prevents the case where we have a full buffer
+      if (typeof item === 'undefined' || atReadPos >= this.writePos) {
+        break;
+      }
+      cb(item[1]);
+      atReadPos += 1;
+    }
+
+    this.timeoutId = setTimeout(() => this.stream(readerId, atReadPos), 500);
+  }
+}
+
+function generateUuidv4(): string {
+  let dt = new Date().getTime();
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    let rnd = Math.random() * 16;
+    rnd = (dt + rnd) % 16 | 0;
+    dt = Math.floor(dt / 16);
+    return (c === 'x' ? rnd : (rnd & 0x3) | 0x8).toString(16);
+  });
+}

--- a/packages/sidecar/src/vite-plugin.js
+++ b/packages/sidecar/src/vite-plugin.js
@@ -5,7 +5,7 @@ export default function spotlightSidecar(port) {
     name: 'spotlightjs-sidecar',
 
     configureServer() {
-      setupSidecar(port);
+      setupSidecar({ port });
     },
   };
 }

--- a/packages/spotlight/bin/run.js
+++ b/packages/spotlight/bin/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 const { setupSidecar } = await import('../dist/sidecar.js');
 const port = process.argv[2];
-setupSidecar(port);
+setupSidecar({ port });


### PR DESCRIPTION
closes #201

This PR adjusts `setupSidecar` to

- accept an `options` object instead of just the port number
- inject a custom logger via the options object
- use a common logger interface and object that invokes the default logger or the custom logger if passed in

Furthermore, this PR:

- updates the Astro Spotlight package to use the Astro inegration logger for the side car
- updates the CLI and Vite plugin APIs for manually using the sidecar

<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [ ] I referenced issues that this PR addresses
