### PR TITLE
meta: Bump `@spotlightjs` packages to version 1.0.0

### DIFF
--- a/.changeset/curvy-bobcats-decide.md
+++ b/.changeset/curvy-bobcats-decide.md
@@ -1,0 +1,12 @@
+---
+'@spotlightjs/astro': major
+'@spotlightjs/overlay': major
+'@spotlightjs/sidecar': major
+'@spotlightjs/spotlight': major
+'@spotlightjs/tsconfig': major
+---
+
+meta: Bump `@spotlightjs` packages to version 1.0.0
+
+This change sets all public `@spotlightjs` packages to major version 1.0.0. From now on, we will follow semantic
+versioning.


### PR DESCRIPTION
🚨 As soon as we merge this, we will need to follow semver and cut minors and majors accordingly!