### PR TITLE
fix(astro): Adjust dev toolbar check after Astro 4.0 stable release

### DIFF
--- a/.changeset/thin-cycles-crash.md
+++ b/.changeset/thin-cycles-crash.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+fix(astro): Adjust dev toolbar check after Astro 4.0 stable release

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -52,7 +52,7 @@ const createPlugin = (options?: SpotlightAstroIntegrationOptions): AstroIntegrat
           // will lead to both of them being enabled by the time this hook is called.
           // Setting one of them to `false` will not set the other one to false.
           // Therefore, both of them have to be `true` that we know that the toolbar is in fact active.
-          const hasToolbarEnabled = config.devToolbar?.enabled && config.devOverlay?.enabled;
+          const hasToolbarEnabled = config.devToolbar?.enabled || config.devOverlay?.enabled;
 
           // Before Astro 4, `devOverlay` was disabled by default and under `experimental`
           const hasExperimentalDevOverlayEnabled = !!(config as AstroConfigWithExperimentalDevOverlay).experimental


### PR DESCRIPTION
Seems like a last minute Astro `4.0.0` stable change caused our previous 4.0.0-beta.4-based check for checking if the dev toolbar is enabled to break. This PR adjusts the check. 