### PR TITLE
Add experiments configuration

### DIFF
--- a/packages/overlay/src/components/Trigger.tsx
+++ b/packages/overlay/src/components/Trigger.tsx
@@ -1,13 +1,10 @@
 import { ComponentPropsWithoutRef } from 'react';
 import { ReactComponent as Logo } from '~/assets/glyph.svg';
+import { DEFAULT_ANCHOR } from '~/constants';
 import classNames from '../lib/classNames';
-import { NotificationCount } from '../types';
+import { NotificationCount, type AnchorConfig } from '../types';
 
-export const DEFAULT_ANCHOR = 'bottomRight';
-
-export type Anchor = 'bottomRight' | 'bottomLeft' | 'centerRight' | 'centerLeft' | 'topLeft' | 'topRight';
-
-function getAnchorClasses(anchor: Anchor) {
+function getAnchorClasses(anchor: AnchorConfig) {
   switch (anchor) {
     case 'centerRight':
       return 'bottom-[45%] right-4';
@@ -61,7 +58,7 @@ export default function Trigger({
   isOpen: boolean;
   setOpen: (value: boolean) => void;
   notificationCount: NotificationCount;
-  anchor?: Anchor;
+  anchor?: AnchorConfig;
 }) {
   const countSum = notificationCount.count;
   const iconSize = 24;

--- a/packages/overlay/src/constants.ts
+++ b/packages/overlay/src/constants.ts
@@ -1,0 +1,7 @@
+export const DEFAULT_SIDECAR_URL = 'http://localhost:8969/stream';
+
+export const DEFAULT_EXPERIMENTS = {
+  'sentry:focus-local-events': true,
+};
+
+export const DEFAULT_ANCHOR = 'bottomRight';

--- a/packages/overlay/src/integrations/integration.ts
+++ b/packages/overlay/src/integrations/integration.ts
@@ -1,9 +1,10 @@
 import { type ComponentType } from 'react';
-import { NotificationCount } from '~/types';
+import { type ExperimentsConfig, type NotificationCount } from '~/types';
 
 export type SpotlightContext = {
   open: (path: string | undefined) => void;
   close: () => void;
+  experiments: ExperimentsConfig;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/overlay/src/integrations/sentry/components/EventList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/EventList.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import Badge from '~/components/Badge';
-import CardList from '~/components/CardList';
+import { useSpotlightContext } from '~/lib/useSpotlightContext';
+import Badge from '../../../components/Badge';
+import CardList from '../../../components/CardList';
 import TimeSince from '../../../components/TimeSince';
 import { useSentryEvents } from '../data/useSentryEvents';
 import { useSentryHelpers } from '../data/useSentryHelpers';
@@ -17,10 +18,11 @@ function renderEvent(event: SentryEvent) {
 export default function EventList() {
   const events = useSentryEvents();
   const helpers = useSentryHelpers();
+  const context = useSpotlightContext();
 
   const matchingEvents = events.filter(e => e.type !== 'transaction');
 
-  const [showAll, setShowAll] = useState(false);
+  const [showAll, setShowAll] = useState(!context.experiments['sentry:focus-local-events']);
   const filteredEvents = showAll
     ? matchingEvents
     : matchingEvents.filter(

--- a/packages/overlay/src/integrations/sentry/components/TraceList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/TraceList.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import CardList from '~/components/CardList';
 import Badge from '../../../components/Badge';
+import CardList from '../../../components/CardList';
 import TimeSince from '../../../components/TimeSince';
 import classNames from '../../../lib/classNames';
+import { useSpotlightContext } from '../../../lib/useSpotlightContext';
 import { useSentryHelpers } from '../data/useSentryHelpers';
 import { useSentryTraces } from '../data/useSentryTraces';
 import { getDuration } from '../utils/duration';
@@ -13,8 +14,9 @@ import PlatformIcon from './PlatformIcon';
 export default function TraceList() {
   const traceList = useSentryTraces();
   const helpers = useSentryHelpers();
+  const context = useSpotlightContext();
 
-  const [showAll, setShowAll] = useState(false);
+  const [showAll, setShowAll] = useState(!context.experiments['sentry:focus-local-events']);
   const filteredTraces = showAll ? traceList : traceList.filter(t => helpers.isLocalToSession(t.trace_id) !== false);
   const hiddenItemCount = traceList.length - filteredTraces.length;
 

--- a/packages/overlay/src/lib/useSpotlightContext.tsx
+++ b/packages/overlay/src/lib/useSpotlightContext.tsx
@@ -1,0 +1,20 @@
+import React, { createContext, useContext, type ReactNode } from 'react';
+import { DEFAULT_EXPERIMENTS } from '../constants';
+import { type SpotlightContext } from '../integrations/integration';
+
+const Context = createContext<SpotlightContext>({
+  open: () => {},
+  close: () => {},
+  experiments: DEFAULT_EXPERIMENTS,
+});
+
+export const SpotlightContextProvider: React.FC<{
+  children: ReactNode;
+  context: SpotlightContext;
+}> = ({ children, context }) => {
+  return <Context.Provider value={context}>{children}</Context.Provider>;
+};
+
+export const useSpotlightContext = () => {
+  return useContext(Context);
+};

--- a/packages/overlay/src/types.ts
+++ b/packages/overlay/src/types.ts
@@ -1,5 +1,10 @@
-import { Anchor } from './components/Trigger';
-import { Integration } from './integrations/integration';
+import { type Integration } from './integrations/integration';
+
+export type ExperimentName = 'sentry:focus-local-events';
+
+export type ExperimentsConfig = Record<ExperimentName, boolean>;
+
+export type AnchorConfig = 'bottomRight' | 'bottomLeft' | 'centerRight' | 'centerLeft' | 'topLeft' | 'topRight';
 
 export type SpotlightOverlayOptions = {
   /**
@@ -59,7 +64,7 @@ export type SpotlightOverlayOptions = {
    *
    * @default "bottomRight"
    */
-  anchor?: Anchor;
+  anchor?: AnchorConfig;
 
   /**
    * If set to `true`, the Spotlight overlay will log additional debug messages to the console.
@@ -72,6 +77,11 @@ export type SpotlightOverlayOptions = {
    * TODO: Remove? No longer needed with new approach
    */
   defaultEventId?: string;
+
+  /**
+   * Experimental configuration.
+   */
+  experiments?: ExperimentsConfig;
 };
 
 export type NotificationCount = {

--- a/packages/website/src/content/docs/reference/configuration.md
+++ b/packages/website/src/content/docs/reference/configuration.md
@@ -70,11 +70,35 @@ init({
 });
 ```
 
+### `experiments`
+
+**type:** [`ExperimentsConfig`](#experimentsconfig)
+
+Experimental configuration.
+
+```ts
+init({
+  experiments: {
+    'sentry:focus-local-events': false,
+  },
+});
+```
+
 #### `AnchorConfig`
 
 ```ts
 type AnchorConfig = 'bottomRight' | 'bottomLeft' | 'centerRight' | 'centerLeft' | 'topLeft' | 'topRight';
 ```
+
+#### `ExperimentsConfig`
+
+```ts
+type ExperimentsConfig = Record<ExperimentName, boolean>;
+```
+
+Experiment names are:
+
+- `sentry:focus-local-events` - if set to true, errors and traces will hide events from other sessions when possible.
 
 ### `injectImmediately`
 
@@ -107,7 +131,7 @@ Trigger an event within Spotlight.
 ```js
 import { trigger } from '@spotlightjs/spotlight';
 
-trigger("sentry:showError", {
+trigger('sentry:showError', {
   event: string,
   eventId: string,
 });


### PR DESCRIPTION
Create a new init param (`experiments`) allowing us to configure additional behavior which may not adhere to semver in change cycles.

Refactors various types and constants.

Refs #230 