### PR TITLE
Add UI to sidecar

### DIFF
--- a/.changeset/afraid-rings-divide.md
+++ b/.changeset/afraid-rings-divide.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/spotlight': minor
+'@spotlightjs/sidecar': minor
+---
+
+Serve Overlay from Sidecar

--- a/.changeset/tasty-rice-camp.md
+++ b/.changeset/tasty-rice-camp.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/sidecar': patch
+---
+
+Fix Sidecar Multitenancy

--- a/packages/sidecar/src/logger.ts
+++ b/packages/sidecar/src/logger.ts
@@ -6,10 +6,10 @@ export type SidecarLogger = {
 };
 
 const defaultLogger: SidecarLogger = {
-  info: (message: string) => console.log(message),
-  warn: (message: string) => console.warn(message),
-  error: (message: string) => console.error(message),
-  debug: (message: string) => console.debug(message),
+  info: (message: string) => console.log('🔎 [Spotlight]', message),
+  warn: (message: string) => console.warn('🔎 [Spotlight]', message),
+  error: (message: string) => console.error('🔎 [Spotlight]', message),
+  debug: (message: string) => console.debug('🔎 [Spotlight]', message),
 };
 
 let injectedLogger: SidecarLogger | undefined = undefined;

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -25,8 +25,8 @@ type SideCarOptions = {
   logger?: SidecarLogger;
 
   /**
-   * The base path of the sidecar.
-   * Defaults to '/dist/overlay'.
+   * The base path from where the static files should be served.
+   * '/dist/overlay' will always be appended to this path.
    */
   basePath?: string;
 };

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -166,6 +166,10 @@ function startServer(buffer: MessageBuffer<Payload>, port: number, basePath?: st
     if (!handled && basePath) {
       serveFile(req, res, basePath);
     }
+    if (!handled && !basePath) {
+      res.writeHead(404);
+      res.end();
+    }
   });
 
   server.on('error', e => {

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -5,7 +5,6 @@ export class MessageBuffer<T> {
   private head = 0;
   private timeout = 10;
   private readers = new Map<string, (item: T) => void>();
-  private timeoutId: NodeJS.Timeout | undefined;
 
   constructor(size = 100) {
     this.size = size;
@@ -33,19 +32,15 @@ export class MessageBuffer<T> {
   subscribe(callback: (item: T) => void): string {
     const readerId = generateUuidv4();
     this.readers.set(readerId, callback);
-    clearTimeout(this.timeoutId);
-    this.timeoutId = setTimeout(() => this.stream(readerId));
+    setTimeout(() => this.stream(readerId));
     return readerId;
   }
 
   unsubscribe(readerId: string): void {
     this.readers.delete(readerId);
-    clearTimeout(this.timeoutId);
   }
 
   stream(readerId: string, readPos = this.head): void {
-    clearTimeout(this.timeoutId);
-
     const cb = this.readers.get(readerId);
     if (!cb) return;
 
@@ -62,7 +57,7 @@ export class MessageBuffer<T> {
       atReadPos += 1;
     }
 
-    this.timeoutId = setTimeout(() => this.stream(readerId, atReadPos), 500);
+    setTimeout(() => this.stream(readerId, atReadPos), 500);
   }
 }
 

--- a/packages/sidecar/src/overlay.html
+++ b/packages/sidecar/src/overlay.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html>
+  <head>
+    <title>Spotlight</title>
+    <!-- Set process for development environment -->
+    <script>
+      window.process = { env: { NODE_ENV: 'development' } };
+    </script>
+    <!-- Load Spotlight.js from the CDN -->
+    <script type="module" src="https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js"></script>
+    <!-- Load inline style for body background -->
+    <style>
+      body {
+        margin: auto;
+        overflow: auto;
+        background: linear-gradient(
+          315deg,
+          rgba(101, 0, 94, 1) 3%,
+          rgba(60, 132, 206, 1) 38%,
+          rgba(48, 238, 226, 1) 68%,
+          rgba(255, 25, 25, 1) 98%
+        );
+        animation: gradient 15s ease infinite;
+        background-size: 400% 400%;
+        background-attachment: fixed;
+      }
+
+      @keyframes gradient {
+        0% {
+          background-position: 0% 0%;
+        }
+        50% {
+          background-position: 100% 100%;
+        }
+        100% {
+          background-position: 0% 0%;
+        }
+      }
+
+      .wave {
+        background: rgb(255 255 255 / 25%);
+        border-radius: 1000% 1000% 0 0;
+        position: fixed;
+        width: 200%;
+        height: 12em;
+        animation: wave 10s -3s linear infinite;
+        transform: translate3d(0, 0, 0);
+        opacity: 0.8;
+        bottom: 0;
+        left: 0;
+        z-index: -1;
+      }
+
+      .wave:nth-of-type(2) {
+        bottom: -1.25em;
+        animation: wave 18s linear reverse infinite;
+        opacity: 0.8;
+      }
+
+      .wave:nth-of-type(3) {
+        bottom: -2.5em;
+        animation: wave 20s -1s reverse infinite;
+        opacity: 0.9;
+      }
+
+      @keyframes wave {
+        2% {
+          transform: translateX(1);
+        }
+
+        25% {
+          transform: translateX(-25%);
+        }
+
+        50% {
+          transform: translateX(-50%);
+        }
+
+        75% {
+          transform: translateX(-25%);
+        }
+
+        100% {
+          transform: translateX(1);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <!-- Import and initialize Spotlight in a separate script tag -->
+    <script type="module">
+      import * as Spotlight from 'https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js';
+      Spotlight.init({
+        openOnInit: true,
+      });
+    </script>
+    <div>
+      <div class="wave"></div>
+      <div class="wave"></div>
+      <div class="wave"></div>
+    </div>
+  </body>
+</html>

--- a/packages/spotlight/bin/run.js
+++ b/packages/spotlight/bin/run.js
@@ -1,4 +1,4 @@
 #!/usr/bin/env node
 const { setupSidecar } = await import('../dist/sidecar.js');
 const port = process.argv[2];
-setupSidecar({ port });
+setupSidecar({ port, basePath: process.cwd() });

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite build --watch",
-    "build": "vite build && tsc",
+    "build": "vite build && vite build --config vite.overlay.config.ts && tsc",
     "build:watch": "vite build --watch",
     "yalc:publish": "yalc publish --push --sig --private",
     "clean": "rimraf dist"

--- a/packages/spotlight/src/index.html
+++ b/packages/spotlight/src/index.html
@@ -2,12 +2,11 @@
 <html>
   <head>
     <title>Spotlight</title>
-    <!-- Set process for development environment -->
-    <script>
-      window.process = { env: { NODE_ENV: 'development' } };
-    </script>
-    <!-- Load Spotlight.js from the CDN -->
-    <script type="module" src="https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js"></script>
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg width='256' height='256' viewBox='0 0 256 256' fill='none' xmlns='http://www.w3.org/2000/svg'%3E%3Cstyle%3E .favicon-stroke %7B %7D %23line %7B fill: black %7D %23outside-dot %7B fill: black %7D %23inside-dot %7B fill: black %7D @media (prefers-color-scheme: dark) %7B %23line %7B fill: white %7D %23outside-dot %7B fill: white %7D %23inside-dot %7B fill: white %7D %7D %3C/style%3E%3Crect width='256' height='256' fill='none' /%3E%3Cpath d='M121.678 68.6777C140.081 50.2742 169.919 50.2742 188.322 68.6777C206.726 87.0811 206.726 116.919 188.322 135.322C169.919 153.726 140.081 153.726 121.678 135.322C120.734 134.378 119.733 133.525 118.686 132.764C108.865 124.59 94.2507 125.11 85.0381 134.322L57.5381 161.822C47.775 171.585 47.775 187.415 57.5381 197.178C67.3012 206.941 83.1303 206.941 92.8934 197.178L104.862 185.209C142.205 207.751 191.449 202.907 223.678 170.678C261.607 132.748 261.607 71.252 223.678 33.3223C185.748 -4.60732 124.252 -4.60732 86.3223 33.3223C77.5523 42.0923 70.7787 52.1712 66.0472 62.9564C60.5003 75.6003 66.2535 90.3468 78.8974 95.8938C91.5413 101.441 106.288 95.6875 111.835 83.0436C114.109 77.8604 117.374 72.9809 121.678 68.6777Z' class='favicon-stroke' id='line' /%3E%3Cpath d='M59 224C59 238.359 47.3594 250 33 250C18.6406 250 7 238.359 7 224C7 209.641 18.6406 198 33 198C47.3594 198 59 209.641 59 224Z' class='favicon-stroke' id='outside-dot' /%3E%3Cpath d='M155 130C170.464 130 183 117.464 183 102C183 86.536 170.464 74 155 74C139.536 74 127 86.536 127 102C127 117.464 139.536 130 155 130Z' class='favicon-stroke' id='inside-dot' /%3E%3C/svg%3E"
+    />
     <!-- Load inline style for body background -->
     <style>
       body {
@@ -89,7 +88,7 @@
   <body>
     <!-- Import and initialize Spotlight in a separate script tag -->
     <script type="module">
-      import * as Spotlight from 'https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js';
+      import * as Spotlight from '@spotlightjs/overlay';
       Spotlight.init({
         openOnInit: true,
       });

--- a/packages/spotlight/vite.overlay.config.ts
+++ b/packages/spotlight/vite.overlay.config.ts
@@ -1,0 +1,13 @@
+import { resolve } from 'path';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    outDir: resolve(__dirname, 'dist', 'overlay'),
+    rollupOptions: {
+      input: {
+        main: resolve(__dirname, 'src', 'index.html'),
+      },
+    },
+  },
+});

--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -109,6 +109,10 @@ export default defineConfig({
               label: 'for Other Frameworks',
               link: '/setup/other/',
             },
+            {
+              label: 'Just HTML',
+              link: '/setup/html/',
+            },
           ],
         },
         {

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -21,7 +21,6 @@
     "@fontsource/raleway": "^5.0.15",
     "@sentry/astro": "^7.85.0",
     "@spotlightjs/astro": "workspace:*",
-    "@spotlightjs/overlay": "workspace:*",
     "@types/react": "^18.2.38",
     "@types/react-dom": "^18.2.17",
     "astro": "^4.0.2",

--- a/packages/website/src/content/docs/setup/html.mdx
+++ b/packages/website/src/content/docs/setup/html.mdx
@@ -1,0 +1,30 @@
+---
+title: Setup Spotlight Overlay directly in HTML
+description: Use the overlay directly in HTML
+---
+
+
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>Spotlight</title>
+    <!-- Set process for development environment -->
+    <script>
+      window.process = { env: { NODE_ENV: 'development' } };
+    </script>
+    <!-- Load Spotlight.js from the CDN -->
+    <script type="module" src="https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js"></script>
+  </head>
+  <body>
+    <!-- Import and initialize Spotlight in a separate script tag -->
+    <script type="module">
+      import * as Spotlight from 'https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js';
+      Spotlight.init({
+        openOnInit: true,
+      });
+    </script>
+  </body>
+</html>
+```

--- a/packages/website/src/content/docs/setup/html.mdx
+++ b/packages/website/src/content/docs/setup/html.mdx
@@ -3,9 +3,12 @@ title: Setup Spotlight Overlay directly in HTML
 description: Use the overlay directly in HTML
 ---
 
+To use Spotlight directly, you can load the script from a CDN and initialize it in a separate script tag.
+
+This solution will probably change in the future, as we are working on a better way to load Spotlight.
 
 
-```html
+```html {7, 10, 14-19}
 <!doctype html>
 <html>
   <head>

--- a/packages/website/src/content/docs/sidecar/index.mdx
+++ b/packages/website/src/content/docs/sidecar/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: What is the Sidecar?
 description: A server forwarding events to Spotlight UI.
+sidebar:
+    order: 0
 ---
 
 The Sidecar uses SSE (Server-Sent Events) to forward events to the Spotlight overlay. It is a standalone server that can be deployed on the same machine as the Spotlight overlay or on a different machine.

--- a/packages/website/src/content/docs/sidecar/npx.mdx
+++ b/packages/website/src/content/docs/sidecar/npx.mdx
@@ -1,5 +1,7 @@
 ---
 title: Run Sidecar with NPX
+sidebar:
+  order: 20
 ---
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
@@ -20,3 +22,7 @@ To run Sidecar independently with NPX, run the following command:
 
 
 This starts the server on port `8969`.
+
+### Built in Overlay
+
+If you start the sidecar independently, you can visit the overlay at `http://localhost:8969/` and use a built in overlay to view your application.

--- a/packages/website/src/content/docs/sidecar/vite.mdx
+++ b/packages/website/src/content/docs/sidecar/vite.mdx
@@ -1,5 +1,7 @@
 ---
 title: Run Sidecar with Vite
+sidebar:
+  order: 30
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/packages/website/src/content/docs/sidecar/webpack.mdx
+++ b/packages/website/src/content/docs/sidecar/webpack.mdx
@@ -1,5 +1,7 @@
 ---
 title: Run Sidecar with Webpack
+sidebar:
+  order: 40
 ---
 
 ```sh

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -436,7 +436,7 @@ packages:
     dependencies:
       '@astrojs/language-server': 2.5.2(prettier@3.0.3)(typescript@5.2.2)
       chokidar: 3.5.3
-      fast-glob: 3.3.1
+      fast-glob: 3.3.2
       kleur: 4.1.5
       typescript: 5.2.2
       yargs: 17.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -367,9 +367,6 @@ importers:
       '@spotlightjs/astro':
         specifier: workspace:*
         version: link:../astro
-      '@spotlightjs/overlay':
-        specifier: workspace:*
-        version: link:../overlay
       '@types/react':
         specifier: ^18.2.38
         version: 18.2.38


### PR DESCRIPTION
So if you run the Sidecar via the binary now it renders the Overlay in the default route inline
http://localhost:8969

```js
#!/usr/bin/env node
const { setupSidecar } = await import('../dist/sidecar.js');
const port = process.argv[2];
setupSidecar({ port, basePath: process.cwd() });
```

it works by providing a base path to decide where the static files should be served from.

If you run 

```base
$ npx spotlight-sidecar
🔎 [Spotlight] Sidecar listening on 8969
🔎 [Spotlight] You can open: http://localhost:8969 to see the Spotlight overlay directly
```
you can open the url.

https://github.com/getsentry/spotlight/assets/363802/fc3ab8e4-2247-43b3-8a1c-40744340a042

Fixes #244 