### PR TITLE
feat(span tree): Added expand/collapse for span item

### DIFF
--- a/.changeset/chilly-tigers-swim.md
+++ b/.changeset/chilly-tigers-swim.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+added expand collapse for spans

--- a/packages/overlay/src/assets/chevronDown.svg
+++ b/packages/overlay/src/assets/chevronDown.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-down" viewBox="0 0 16 16">
+  <path fill-rule="evenodd" d="M1.646 4.646a.5.5 0 0 1 .708 0L8 10.293l5.646-5.647a.5.5 0 0 1 .708.708l-6 6a.5.5 0 0 1-.708 0l-6-6a.5.5 0 0 1 0-.708z"/>
+</svg>

--- a/packages/overlay/src/integrations/sentry/components/SpanItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/SpanItem.tsx
@@ -1,0 +1,93 @@
+import { useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { ReactComponent as ChevronIcon } from '~/assets/chevronDown.svg';
+import classNames from '../../../lib/classNames';
+import { Span, TraceContext } from '../types';
+import { getDuration, getSpanDurationClassName } from '../utils/duration';
+import PlatformIcon from './PlatformIcon';
+import SpanTree from './SpanTree';
+
+const SpanItem = ({
+  span,
+  startTimestamp,
+  totalDuration,
+  depth = 1,
+  traceContext,
+}: {
+  span: Span;
+  startTimestamp: number;
+  totalDuration: number;
+  depth?: number;
+  traceContext: TraceContext;
+}) => {
+  const { spanId } = useParams();
+  const [renderChildren, setRenderChildren] = useState(depth <= 5);
+
+  const spanDuration = getDuration(span.start_timestamp, span.timestamp);
+
+  return (
+    <li key={span.span_id} className="pl-4">
+      <Link
+        className={classNames(
+          'hover:bg-primary-900 flex cursor-pointer text-sm',
+          spanId === span.span_id ? 'bg-primary-900' : '',
+        )}
+        to={`/traces/${span.trace_id}/${span.span_id}`}
+      >
+        <div className={classNames('node', span.status && span.status !== 'ok' ? 'text-red-400' : '')}>
+          {(span.children || []).length > 0 && (
+            <div
+              className="bg-primary-600 mr-1 flex items-center gap-1 rounded-lg px-1 text-xs font-bold text-white"
+              onClick={e => {
+                e.preventDefault();
+                setRenderChildren(prev => !prev);
+              }}
+            >
+              {(span.children || []).length}
+              <ChevronIcon
+                width={12}
+                height={12}
+                className={classNames('transition', renderChildren ? 'rotate-180' : 'rotate-0')}
+              />
+            </div>
+          )}
+          {span.transaction && <PlatformIcon size={16} platform={span.transaction.platform} />}
+          {span.op && (
+            <>
+              <span className="font-bold">{span.op}</span>
+              <span className="text-primary-400">&ndash;</span>
+            </>
+          )}
+          <span className="block max-w-sm truncate" title={span.description || span.span_id}>
+            {span.description || span.span_id}
+          </span>
+        </div>
+        <div className="waterfall">
+          <div
+            className="bg-primary-900 absolute -m-0.5 w-full p-0.5"
+            style={{
+              left: `min(${((span.start_timestamp - startTimestamp) / totalDuration) * 100}%, 95% - 1px)`,
+              width: `max(1px, ${(spanDuration / totalDuration) * 95}%)`,
+            }}
+          >
+            <span className={classNames('whitespace-nowrap', getSpanDurationClassName(spanDuration))}>
+              {spanDuration.toLocaleString()} ms
+            </span>
+          </div>
+        </div>
+      </Link>
+
+      {renderChildren && (
+        <SpanTree
+          traceContext={traceContext}
+          tree={span.children || []}
+          startTimestamp={startTimestamp}
+          totalDuration={totalDuration}
+          depth={depth + 1}
+        />
+      )}
+    </li>
+  );
+};
+
+export default SpanItem;

--- a/packages/overlay/src/integrations/sentry/components/SpanTree.tsx
+++ b/packages/overlay/src/integrations/sentry/components/SpanTree.tsx
@@ -1,8 +1,5 @@
-import { Link, useParams } from 'react-router-dom';
-import classNames from '../../../lib/classNames';
 import { Span, TraceContext } from '../types';
-import { getDuration, getSpanDurationClassName } from '../utils/duration';
-import PlatformIcon from './PlatformIcon';
+import SpanItem from './SpanItem';
 
 export default function SpanTree({
   traceContext,
@@ -17,57 +14,19 @@ export default function SpanTree({
   totalDuration: number;
   depth?: number;
 }) {
-  const { spanId } = useParams();
-
   if (!tree || !tree.length) return null;
 
   return (
     <ul className="tree">
       {tree.map(span => {
-        const spanDuration = getDuration(span.start_timestamp, span.timestamp);
         return (
-          <li key={span.span_id} className="pl-4">
-            <Link
-              className={classNames(
-                'hover:bg-primary-900 flex cursor-pointer text-sm',
-                spanId === span.span_id ? 'bg-primary-900' : '',
-              )}
-              to={`/traces/${span.trace_id}/${span.span_id}`}
-            >
-              <div className={classNames('node', span.status && span.status !== 'ok' ? 'text-red-400' : '')}>
-                {span.transaction && <PlatformIcon size={16} platform={span.transaction.platform} />}
-                {span.op && (
-                  <>
-                    <span className="font-bold">{span.op}</span>
-                    <span className="text-primary-400">&ndash;</span>
-                  </>
-                )}
-                <span className="block max-w-sm truncate" title={span.description || span.span_id}>
-                  {span.description || span.span_id}
-                </span>
-              </div>
-              <div className="waterfall">
-                <div
-                  className="bg-primary-900 absolute -m-0.5 w-full p-0.5"
-                  style={{
-                    left: `min(${((span.start_timestamp - startTimestamp) / totalDuration) * 100}%, 95% - 1px)`,
-                    width: `max(1px, ${(spanDuration / totalDuration) * 95}%)`,
-                  }}
-                >
-                  <span className={classNames('whitespace-nowrap', getSpanDurationClassName(spanDuration))}>
-                    {spanDuration.toLocaleString()} ms
-                  </span>
-                </div>
-              </div>
-            </Link>
-            <SpanTree
-              traceContext={traceContext}
-              tree={span.children || []}
-              startTimestamp={startTimestamp}
-              totalDuration={totalDuration}
-              depth={depth + 1}
-            />
-          </li>
+          <SpanItem
+            traceContext={traceContext}
+            depth={depth}
+            span={span}
+            startTimestamp={startTimestamp}
+            totalDuration={totalDuration}
+          />
         );
       })}
     </ul>


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [x] I referenced issues that this PR addresses
fixes: #236 

- collapsed tree after depth of 5
- added a button for every span with children to collapse/expand the tree.

https://vimeo.com/892532538/1448e14bc0?share=copy