### PR TITLE
return 200 instead of 204 on stream endpoint

### DIFF
--- a/.changeset/light-apes-applaud.md
+++ b/.changeset/light-apes-applaud.md
@@ -2,4 +2,4 @@
 '@spotlightjs/sidecar': minor
 ---
 
-stream endpoint returns 200 instead of 204
+ref(sidecar): Stream endpoint returns 200 instead of 204

--- a/.changeset/light-apes-applaud.md
+++ b/.changeset/light-apes-applaud.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/sidecar': minor
+---
+
+stream endpoint returns 200 instead of 204

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -114,7 +114,8 @@ function handleStreamRequest(req: IncomingMessage, res: ServerResponse, buffer: 
             logger.info(`🗃️ Saved data to ${filename}`);
           }
 
-          res.writeHead(204, {
+          // 204 would be more appropriate but returning 200 to match what /envelope returns
+          res.writeHead(200, {
             'Cache-Control': 'no-cache',
             ...getCorsHeader(),
             Connection: 'keep-alive',


### PR DESCRIPTION
With this change, I can merge https://github.com/getsentry/sentry-dotnet/pull/2961 as-is since it relies on all of Sentry's HTTP logic (including retry-after, etc). 

Otherwise I'll need to customize it to deal with 200 or 204, which is fine but since I imagine this might hit other SDKs adding support, changing the status code here might be the simplest.