### PR TITLE
install instructions dotnet

### DIFF
--- a/packages/website/src/components/sentryCodeBlock.mdx
+++ b/packages/website/src/components/sentryCodeBlock.mdx
@@ -66,7 +66,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   :::caution
   Requires `sentry-dotnet` version `4.0.0` or higher.
   :::
-  ```csharp
+  ```csharp {3-6}
   SentrySdk.Init(o =>
   {
       o.Dsn = "___DSN___";

--- a/packages/website/src/components/sentryCodeBlock.mdx
+++ b/packages/website/src/components/sentryCodeBlock.mdx
@@ -8,11 +8,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   <TabItem label="JavaScript (Browser)">
   In the Browser you don't need to set `spotlight: true`, `Spotlight.init()` will automatically detect if Sentry is available and if so, hook into the SDK.
   ```javascript {5}
-    Sentry.init({
-      dsn: '___DSN___',
-    });
-    // In the frontend it's important that you init Spotlight after Sentry
-    Spotlight.init();
+  Sentry.init({
+    dsn: '___DSN___',
+  });
+  // In the frontend it's important that you init Spotlight after Sentry
+  Spotlight.init();
   ```
   </TabItem>
   <TabItem label="Node">
@@ -20,10 +20,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   Requires `@sentry/node` version `7.82.0` or higher.
   :::
   ```javascript {3}
-    Sentry.init({
-        dsn: '___DSN___',
-        spotlight: process.env.NODE_ENV === "development",
-    });
+  Sentry.init({
+      dsn: '___DSN___',
+      spotlight: process.env.NODE_ENV === "development",
+  });
   ```
   </TabItem>
   <TabItem label="Python">
@@ -31,11 +31,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   Requires `sentry-sdk` version `1.37.0` or higher.
   :::
   ```python {4}
-    sentry_sdk.init(
-        dsn="___DSN___",
-        # You should only load this in your development environment
-        spotlight=bool(os.environ.get("DEV")),
-    )
+  sentry_sdk.init(
+      dsn="___DSN___",
+      # You should only load this in your development environment
+      spotlight=bool(os.environ.get("DEV")),
+  )
   ```
   </TabItem>
   <TabItem label="PHP">
@@ -43,11 +43,11 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   Requires `sentry/sentry` version `4.1.0` or higher.
   :::
   ```php {4}
-    \Sentry\init([
-        'dsn' => '___DSN___',
-        // You should only load this in your development environment
-        'spotlight' => App::environment(['local']),
-    ]);
+  \Sentry\init([
+      'dsn' => '___DSN___',
+      // You should only load this in your development environment
+      'spotlight' => App::environment(['local']),
+  ]);
   ```
   </TabItem>
   <TabItem label="Ruby">
@@ -55,11 +55,26 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   Requires `sentry-ruby` version `5.15.0` or higher.
   :::
   ```ruby {4}
-    Sentry.init do |config|
-        config.dsn = '___DSN___'
-        # You should only load this in your development environment
-        config.spotlight = Rails.env.development?
-    end
+  Sentry.init do |config|
+      config.dsn = '___DSN___'
+      # You should only load this in your development environment
+      config.spotlight = Rails.env.development?
+  end
+  ```
+  </TabItem>
+  <TabItem label=".NET">
+  :::caution
+  Requires `sentry-dotnet` version `4.0.0` or higher.
+  :::
+  ```csharp
+  SentrySdk.Init(o =>
+  {
+      o.Dsn = "___DSN___";
+#if DEBUG
+      // You should only load this in your development environment
+      o.EnableSpotlight = true;
+#endif
+  });
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Do I need a changeset for this? No package for the website showed for selection.

1.  Moved all snippets back a few characters, has enough padding IMO:

<img width="788" alt="image" src="https://github.com/getsentry/spotlight/assets/1633368/f372d0ed-db1c-440d-9bc5-b6a7db6b0fee">

<img width="760" alt="image" src="https://github.com/getsentry/spotlight/assets/1633368/75871e59-ce72-49d5-b803-9090f9437f65">


2. Added .NET (not ASP.NET Core or other framework but this should be clear enough):
<img width="761" alt="image" src="https://github.com/getsentry/spotlight/assets/1633368/91e8df89-a3d7-4880-92c8-29c9da3e7057">

ASP.NET Core has built-in environment (and env var `ASPNETCORE_ENVIRONMENT` but not referring to it here for simplicity). Also with ASP.NET Core you usr `UseSentry(o => ` instead of `SentrySdk.Init`.


Note the option now is called `EnableSpotlight` not aligning. The option to set a custom URL is `SpotlightUrl`. We could have `Spotlight` as a prop and use `implicit` operators to allow assigning either `string` or `bool` to it but it feels like a hack in C#. I expect us to have more props in the future Spotlight related and wanted to leave `Spotlight` as a name free to avoid breaking changes later so we can add a `SpotlightOption` class and prop `Spotlight`.

Finally, note that we're on `4.0.0-beta.5` now. Didn't list the `-beta.X` there to simplify things.
