### PR TITLE
@spotlightjs/astro: Fix importing arbitrary paths on Windows

### DIFF
--- a/.changeset/many-bears-perform.md
+++ b/.changeset/many-bears-perform.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/astro': patch
+---
+
+Fix issue on Windows caused by importing arbitrary paths

--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -9,7 +9,7 @@ export type ClientInitOptions = {
   injectImmediately?: boolean;
 } & SpotlightAstroIntegrationOptions;
 
-const buildClientImport = (importPath: string) => `import * as Spotlight from '${importPath}';`;
+const buildClientImport = (importPath: string) => `import * as Spotlight from ${JSON.stringify(importPath)};`;
 
 const buildClientInit = (options: ClientInitOptions) => {
   const integrationCalls = options.integrationNames


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [x] I referenced issues that this PR addresses

---
## Changes
Use `JSON.stringify` when injecting arbitrary paths so it works on Windows (backslashes wont cause problems)
## Related
Fix https://github.com/withastro/astro/issues/9389
Astro's fix PR https://github.com/withastro/astro/pull/9400
## Notes
Spotlight's Astro integration, for some reason, does its own import via vite while registering another import via Astro's Dev Toolbar API. Unfortunately both have the same issue related to absolute path and `\` on Windows. This PR fixes the former while https://github.com/withastro/astro/pull/9400 fixes the latter(not yet landed).

`JSON.stringify` is used in the fix as well as https://github.com/withastro/astro/pull/9400 .