### PR TITLE
Added condition to make SpanTree collapsible

### DIFF
--- a/.changeset/sour-boxes-boil.md
+++ b/.changeset/sour-boxes-boil.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+added condition to make SpanTree collapsible

--- a/packages/overlay/src/integrations/sentry/components/SpanDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/SpanDetails.tsx
@@ -34,11 +34,13 @@ export default function SpanDetails({
   span,
   startTimestamp,
   totalDuration,
+  collapsible = false,
 }: {
   traceContext: TraceContext;
   span: Span;
   startTimestamp: number;
   totalDuration: number;
+  collapsible?: boolean;
 }) {
   const spanDuration = getDuration(span.start_timestamp, span.timestamp);
 
@@ -209,6 +211,7 @@ export default function SpanDetails({
               tree={[span]}
               startTimestamp={startTimestamp}
               totalDuration={totalDuration}
+              collapsible={collapsible}
             />
           </div>
         )}

--- a/packages/overlay/src/integrations/sentry/components/SpanItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/SpanItem.tsx
@@ -13,15 +13,17 @@ const SpanItem = ({
   totalDuration,
   depth = 1,
   traceContext,
+  collapsible = false,
 }: {
   span: Span;
   startTimestamp: number;
   totalDuration: number;
   depth?: number;
   traceContext: TraceContext;
+  collapsible?: boolean;
 }) => {
   const { spanId } = useParams();
-  const [renderChildren, setRenderChildren] = useState(depth <= 5);
+  const [renderChildren, setRenderChildren] = useState(!collapsible || depth <= 5);
 
   const spanDuration = getDuration(span.start_timestamp, span.timestamp);
 
@@ -35,7 +37,7 @@ const SpanItem = ({
         to={`/traces/${span.trace_id}/${span.span_id}`}
       >
         <div className={classNames('node', span.status && span.status !== 'ok' ? 'text-red-400' : '')}>
-          {(span.children || []).length > 0 && (
+          {collapsible && (span.children || []).length > 0 && (
             <div
               className="bg-primary-600 mr-1 flex items-center gap-1 rounded-lg px-1 text-xs font-bold text-white"
               onClick={e => {
@@ -84,6 +86,7 @@ const SpanItem = ({
           startTimestamp={startTimestamp}
           totalDuration={totalDuration}
           depth={depth + 1}
+          collapsible={collapsible}
         />
       )}
     </li>

--- a/packages/overlay/src/integrations/sentry/components/SpanTree.tsx
+++ b/packages/overlay/src/integrations/sentry/components/SpanTree.tsx
@@ -7,12 +7,14 @@ export default function SpanTree({
   startTimestamp,
   totalDuration,
   depth = 1,
+  collapsible = false,
 }: {
   traceContext: TraceContext;
   tree: Span[];
   startTimestamp: number;
   totalDuration: number;
   depth?: number;
+  collapsible?: boolean;
 }) {
   if (!tree || !tree.length) return null;
 
@@ -27,6 +29,7 @@ export default function SpanTree({
             span={span}
             startTimestamp={startTimestamp}
             totalDuration={totalDuration}
+            collapsible={collapsible}
           />
         );
       })}

--- a/packages/overlay/src/integrations/sentry/components/TraceDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/TraceDetails.tsx
@@ -18,6 +18,7 @@ export default function TraceDetails() {
 
   const startTimestamp = trace.start_timestamp;
   const totalDuration = trace.timestamp - startTimestamp;
+  const isCollapsible = trace.transactions.length > 1 || trace.spans.length >= 50;
 
   return (
     <>
@@ -55,10 +56,17 @@ export default function TraceDetails() {
           tree={trace.spanTree}
           startTimestamp={startTimestamp}
           totalDuration={totalDuration}
+          collapsible={isCollapsible}
         />
       </div>
       {span ? (
-        <SpanDetails traceContext={trace} startTimestamp={startTimestamp} totalDuration={totalDuration} span={span} />
+        <SpanDetails
+          traceContext={trace}
+          startTimestamp={startTimestamp}
+          totalDuration={totalDuration}
+          span={span}
+          collapsible={isCollapsible}
+        />
       ) : null}
     </>
   );


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [x] I referenced issues that this PR addresses
fixes: #278 
Added a condition to make spanTree collapsible -> in a trace when transactions > 1 || spans >=50