### PR TITLE
Fixes sorting of spans accross browsers

### DIFF
--- a/.changeset/spotty-fireants-unite.md
+++ b/.changeset/spotty-fireants-unite.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+fixed sorting of spans across browsers

--- a/packages/overlay/src/integrations/sentry/utils/traces.ts
+++ b/packages/overlay/src/integrations/sentry/utils/traces.ts
@@ -8,8 +8,8 @@ export function groupSpans(spans: Span[]) {
   // hash with pointers
   const idLookup = new Map<string, Span>();
 
-  const sortedSpans = [...spans] // need to sort root(s) first
-    .sort(a => (a.parent_span_id ? 1 : 0));
+  // need to sort root(s) first
+  const sortedSpans = [...spans].sort((a, b) => (a.parent_span_id ? 1 : 0) - (b.parent_span_id ? 1 : 0));
 
   sortedSpans.forEach(span => {
     let parent = getParentOfSpan(span, idLookup, sortedSpans);


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [x] I referenced issues that this PR addresses

fixes: #262 


