### PR TITLE
some overlay ui improvements

### DIFF
--- a/.changeset/orange-points-dress.md
+++ b/.changeset/orange-points-dress.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+ui improvements

--- a/packages/overlay/src/components/Overview.tsx
+++ b/packages/overlay/src/components/Overview.tsx
@@ -49,23 +49,25 @@ export default function Overview({
   return (
     <>
       <Tabs tabs={tabs} setOpen={setOpen} />
-      <Routes>
-        <Route path="/not-found" element={<p>Not Found - How'd you manage to get here?</p>} key={'not-found'}></Route>
-        {tabs.map(tab => {
-          const TabContent = tab.content && tab.content;
+      <div className="flex-1 overflow-auto overflow-x-hidden">
+        <Routes>
+          <Route path="/not-found" element={<p>Not Found - How'd you manage to get here?</p>} key={'not-found'}></Route>
+          {tabs.map(tab => {
+            const TabContent = tab.content && tab.content;
 
-          if (TabContent) {
-            return (
-              <Route
-                path={`/${tab.id}/*`}
-                key={tab.id}
-                element={createElement(TabContent, { processedEvents: tab.processedEvents })}
-              ></Route>
-            );
-          }
-          return null;
-        })}
-      </Routes>
+            if (TabContent) {
+              return (
+                <Route
+                  path={`/${tab.id}/*`}
+                  key={tab.id}
+                  element={createElement(TabContent, { processedEvents: tab.processedEvents })}
+                ></Route>
+              );
+            }
+            return null;
+          })}
+        </Routes>
+      </div>
     </>
   );
 }

--- a/packages/overlay/src/components/Tabs.tsx
+++ b/packages/overlay/src/components/Tabs.tsx
@@ -52,7 +52,7 @@ export default function Tabs({ tabs, nested, setOpen }: Props) {
         <select
           id="tabs"
           name="tabs"
-          className="focus:border-primary-500 focus:ring-primary-500 block w-full rounded-md border-gray-300 py-2 pl-3 pr-10 text-base focus:outline-none sm:text-sm"
+          className="border-primary-800 bg-primary-800 hover:bg-primary-700 hover:border-primary-700 focus:bg-primary-800 text-primary-100 block w-full rounded-md py-2 pl-3 pr-10 focus:outline-none sm:text-sm"
           onChange={e => {
             const activeTab = tabs.find(tab => tab.id === e.target.value);
             if (activeTab && activeTab.onSelect) {

--- a/packages/overlay/src/index.css
+++ b/packages/overlay/src/index.css
@@ -3,12 +3,12 @@
 @tailwind utilities;
 
 .spotlight-fullscreen-blur {
-  @apply fixed flex h-screen w-screen flex-col overflow-auto bg-black bg-opacity-50 backdrop-blur-sm backdrop-filter;
+  @apply fixed flex h-screen w-screen flex-col overflow-hidden bg-black bg-opacity-50 backdrop-blur-sm backdrop-filter;
   z-index: 999998;
 }
 
 .spotlight-debugger {
-  @apply from-primary-900 to-primary-950 flex h-full flex-col overflow-auto overflow-x-hidden rounded-lg bg-gradient-to-br to-20% font-sans text-white shadow-xl;
+  @apply from-primary-900 to-primary-950 flex h-full flex-col overflow-hidden rounded-lg bg-gradient-to-br to-20% font-sans text-white shadow-xl;
   margin: 2.5vh;
 }
 
@@ -19,30 +19,6 @@
 .spotlight-sidepanel {
   -webkit-app-region: no-drag;
 }
-
-/* .sentry-debugger .tree li {
-  position: relative;
-}
-.sentry-debugger .tree li > div > div {
-  position: relative;
-}
-
-.sentry-debugger .tree li .node::before {
-  @apply border-b-2 border-primary-400 border-l-2;
-
-  display: block;
-  left: -10px;
-  width: 10px;
-  content: "";
-  margin-top: -13px;
-  height: 15px;
-}
-
-.sentry-debugger .tree li:first-child .node::before {
-}
-
-.sentry-debugger .tree li:last-child .node::before {
-} */
 
 ul.tree {
   position: relative;
@@ -107,11 +83,3 @@ ul.tree li:last-child:before {
 .table-values tbody td {
   @apply border-primary-950 border-y px-2 py-1;
 }
-
-/* 
-<th className="w-/12 text-left text-primary-300 font-normal font-mono pr-4 py-0.5">
-<div className="truncate w-full">{key}</div>
-</th>
-<td className="py-0.5">
-<pre className="whitespace-nowrap font-mono">{value}</pre>
-</td> */

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -126,6 +126,7 @@ export async function init({
   if (fullPage) {
     docRoot.style.height = '100%';
     docRoot.style.backgroundColor = colors.indigo[950];
+    appRoot.style.height = 'inherit';
   } else {
     appRoot.style.position = 'absolute';
     appRoot.style.top = '0';


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [ ] I referenced issues that this PR addresses

Change - 
- instead of scrolling the full page, the header and tabs will now be sticky.
- fixed colors for mobile tab selection

Before
![image](https://github.com/getsentry/spotlight/assets/43654389/eb94f797-2e5b-43e3-a395-ff6245502745)
![image](https://github.com/getsentry/spotlight/assets/43654389/61a73ab8-097f-4136-91fd-d4dd5adc3918)



After
![image](https://github.com/getsentry/spotlight/assets/43654389/228beb4d-6309-4718-878d-f1de40799c65)
![image](https://github.com/getsentry/spotlight/assets/43654389/4374ec12-5621-43b7-926b-9ee628b7eff3)
