### PR TITLE
fixes: error stacktrace reversing

### DIFF
--- a/.changeset/wicked-olives-roll.md
+++ b/.changeset/wicked-olives-roll.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Reverse the error stack trace for php and python platform events

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -241,11 +241,13 @@ function reverseStackTraces(errorEvent: SentryErrorEvent): void {
   if (!errorEvent.exception || !errorEvent.exception.values) {
     return;
   }
+
+  // TODO: To check if stacktrace is already reverse or not for php and python.
   // Check if errorEvent.platform contains php, or python and if so return early
   // as the stacktrace is already in the correct order.
-  if (errorEvent.platform && (errorEvent.platform.includes('php') || errorEvent.platform.includes('python'))) {
-    return;
-  }
+  // if (errorEvent.platform && (errorEvent.platform.includes('php') || errorEvent.platform.includes('python'))) {
+  //   return;
+  // }
   errorEvent.exception.values.forEach(value => {
     if (value.stacktrace) {
       value.stacktrace.frames.reverse();

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -242,12 +242,6 @@ function reverseStackTraces(errorEvent: SentryErrorEvent): void {
     return;
   }
 
-  // TODO: To check if stacktrace is already reverse or not for php and python.
-  // Check if errorEvent.platform contains php, or python and if so return early
-  // as the stacktrace is already in the correct order.
-  // if (errorEvent.platform && (errorEvent.platform.includes('php') || errorEvent.platform.includes('python'))) {
-  //   return;
-  // }
   errorEvent.exception.values.forEach(value => {
     if (value.stacktrace) {
       value.stacktrace.frames.reverse();


### PR DESCRIPTION
<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [x] I referenced issues that this PR addresses
#294 

Removed the logic to not reverse the stacktrace of error events when platform is PHP or python.