### PR TITLE
docs(nextjs): Remove SvelteKit reference in next.js doc

### DIFF
--- a/packages/website/src/content/docs/setup/nextjs.mdx
+++ b/packages/website/src/content/docs/setup/nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: Using Spotlight with Next.js
-description: A guide how to setup Spotlight for Next.js
+description: A guide on how to setup Spotlight for Next.js
 ---
 
 import { Content as InstallCommand } from "../../../components/InstallCommand.mdx";
@@ -26,8 +26,6 @@ Before integrating Spotlight with Next.js, make sure you have the following prer
   Requires `@sentry/nextjs` version `7.82.0` or higher.
 :::
 Initialize Spotlight within `sentry.client.config.js`, after you've initialized the Sentry:
-
-Initialize Spotlight after Sentry and start the Sidecar on the server. Just add a little code to your [SvelteKit hooks](https://kit.svelte.dev/docs/hooks) files:
 
 <Tabs>
 


### PR DESCRIPTION
- Fix grammar error in description metadata
- Remove SvelteKit reference in next.js doc

<!-- 
Tick these boxes IF they're applicable for your PR.
- Changesets are only required for PRs to Spotlight lbirary packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first. 
-->
Before opening this PR:
* [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
* [ ] I referenced issues that this PR addresses
