### PR TITLE
feat(performance): Web vitals added

### DIFF
--- a/.changeset/good-balloons-compete.md
+++ b/.changeset/good-balloons-compete.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': minor
+---
+
+Added WebVitals in Performance Section

--- a/packages/overlay/src/components/RingChart.tsx
+++ b/packages/overlay/src/components/RingChart.tsx
@@ -1,0 +1,146 @@
+import type { ReactNode } from 'react';
+import { useMemo } from 'react';
+import classNames from '~/lib/classNames';
+
+type Props = React.HTMLAttributes<SVGSVGElement> & {
+  backgroundColors: string[];
+  maxValues: number[];
+  segmentColors: string[];
+  text: React.ReactNode;
+  values: number[];
+  /**
+   * The width of the progress ring bar
+   */
+  barWidth?: number;
+  onHoverActions?: (() => void)[];
+  onUnhover?: () => void;
+  /**
+   * Endcaps on the progress bar
+   */
+  progressEndcaps?: React.SVGAttributes<SVGCircleElement>['strokeLinecap'];
+  size?: number;
+  /**
+   * The css to apply to the center text. A function may be provided to compute
+   * styles based on the state of the progress bar.
+   */
+  textCss?: string;
+  x?: number;
+  y?: number;
+};
+
+const BASE_ROTATE = -90;
+const PADDING = 1;
+
+function RingChart({
+  values,
+  maxValues,
+  size = 20,
+  barWidth = 3,
+  text,
+  textCss,
+  segmentColors,
+  backgroundColors,
+  progressEndcaps,
+  onHoverActions,
+  onUnhover,
+  ...p
+}: Props) {
+  const foreignObjectSize = size / 2;
+  const foreignObjectOffset = size / 4;
+
+  const radius = size / 2 - barWidth / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  const rings = useMemo<ReactNode[]>(() => {
+    const sumMaxValues = maxValues.reduce((acc, val) => acc + val, 0);
+    let currentRotate = BASE_ROTATE;
+
+    return maxValues.flatMap((maxValue, index) => {
+      const boundedValue = Math.min(Math.max(values[index], 0), maxValue);
+      const ringSegmentPadding = values.length > 1 ? PADDING : 0;
+      const maxOffset = (1 - Math.max(maxValue - ringSegmentPadding, 0) / sumMaxValues) * circumference;
+      const progressOffset = (1 - Math.max(boundedValue - ringSegmentPadding, 0) / sumMaxValues) * circumference;
+      const rotate = currentRotate;
+      currentRotate += (360 * maxValue) / sumMaxValues;
+
+      const cx = radius + barWidth / 2;
+      const key = `${cx}-${backgroundColors[index]}`;
+
+      return [
+        <circle
+          key={`ring-bg-${key}`}
+          strokeDashoffset={maxOffset}
+          r={radius}
+          cx={cx}
+          cy={cx}
+          onMouseOver={() => onHoverActions?.[index]()}
+          onMouseLeave={() => onUnhover?.()}
+          className={classNames(backgroundColors[index])}
+          style={{
+            fill: 'none',
+            strokeWidth: barWidth,
+            strokeDasharray: `${circumference} ${circumference}`,
+            transform: `rotate(${rotate}deg)`,
+            transformOrigin: '50% 50%',
+            transition: `stroke 300ms`,
+          }}
+        />,
+        <circle
+          key={`ring-bar-${key}`}
+          strokeDashoffset={progressOffset}
+          strokeLinecap={progressEndcaps}
+          r={radius}
+          cx={cx}
+          cy={cx}
+          onMouseOver={() => onHoverActions?.[index]()}
+          onMouseLeave={() => onUnhover?.()}
+          className={classNames(segmentColors[index])}
+          style={{
+            fill: 'none',
+            strokeWidth: barWidth,
+            strokeDasharray: `${circumference} ${circumference}`,
+            transform: `rotate(${rotate}deg)`,
+            transformOrigin: '50% 50%',
+            transition: `stroke 300ms, stroke-dashoffset 300ms`,
+          }}
+        />,
+      ];
+    });
+  }, [
+    backgroundColors,
+    barWidth,
+    circumference,
+    maxValues,
+    onHoverActions,
+    onUnhover,
+    progressEndcaps,
+    radius,
+    segmentColors,
+    values,
+  ]);
+
+  return (
+    <svg className="relative" role="img" height={radius * 2 + barWidth} width={radius * 2 + barWidth} {...p}>
+      {rings}
+      <foreignObject
+        height={foreignObjectSize}
+        width={foreignObjectSize}
+        x={foreignObjectOffset}
+        y={foreignObjectOffset}
+      >
+        {text !== undefined ? (
+          <div
+            className={classNames(
+              'text-primary-100 flex h-full w-full items-center justify-center text-xl font-bold',
+              textCss,
+            )}
+          >
+            {text}
+          </div>
+        ) : null}
+      </foreignObject>
+    </svg>
+  );
+}
+
+export default RingChart;

--- a/packages/overlay/src/components/RingChart.tsx
+++ b/packages/overlay/src/components/RingChart.tsx
@@ -64,7 +64,7 @@ function RingChart({
       currentRotate += (360 * maxValue) / sumMaxValues;
 
       const cx = radius + barWidth / 2;
-      const key = `${cx}-${backgroundColors[index]}`;
+      const key = `${cx}-${backgroundColors[index]}-${segmentColors[index]}`;
 
       return [
         <circle

--- a/packages/overlay/src/components/Tabs.tsx
+++ b/packages/overlay/src/components/Tabs.tsx
@@ -80,7 +80,7 @@ export default function Tabs({ tabs, nested, setOpen }: Props) {
                   isActive
                     ? 'border-primary-200 text-primary-100 [&>.count]:bg-primary-100 [&>.count]:text-primary-600'
                     : 'text-primary-400 hover:border-primary-400 hover:text-primary-100 [&>.count]:bg-primary-700 [&>.count]:text-primary-200 border-transparent',
-                  '-m-y -mx-2 flex whitespace-nowrap border-b-2 px-2 py-3 text-sm font-medium',
+                  '-m-y -mx-2 flex select-none whitespace-nowrap border-b-2 px-2 py-3 text-sm font-medium',
                 )
               }
               onClick={() => tab.onSelect && tab.onSelect()}

--- a/packages/overlay/src/integrations/sentry/components/Performance/PerformanceTabDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/PerformanceTabDetails.tsx
@@ -7,6 +7,8 @@ import HiddenItemsButton from '../HiddenItemsButton';
 import Queries from './Queries';
 import QuerySummary from './QuerySummary';
 import Resources from './Resources';
+import WebVitals from './WebVitals';
+import WebVitalsDetail from './WebVitals/WebVitalsDetail';
 
 export default function PerformanceTabDetails() {
   const context = useSpotlightContext();
@@ -23,6 +25,12 @@ export default function PerformanceTabDetails() {
       title: 'Queries',
       active: activeTab === 'queries',
       onSelect: () => setActiveTab('queries'),
+    },
+    {
+      id: 'webvitals',
+      title: 'Web Vitals',
+      active: activeTab === 'webvitals',
+      onSelect: () => setActiveTab('webvitals'),
     },
     {
       id: 'resources',
@@ -47,6 +55,8 @@ export default function PerformanceTabDetails() {
         <Routes>
           <Route path="queries/:type" element={<QuerySummary showAll={showAll} />} />
           <Route path="resources" element={<Resources showAll={showAll} />} />
+          <Route path="webvitals" element={<WebVitals showAll={showAll} />} />
+          <Route path="webvitals/:page" element={<WebVitalsDetail />} />
           {/* Default tab */}
           <Route path="*" element={<Queries showAll={showAll} />} />
         </Routes>

--- a/packages/overlay/src/integrations/sentry/components/Performance/Queries.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/Queries.tsx
@@ -105,7 +105,7 @@ const Queries = ({ showAll }: { showAll: boolean }) => {
                 key={header.id}
                 scope="col"
                 className={classNames(
-                  'text-primary-100 px-6 py-3.5 text-sm font-semibold',
+                  'text-primary-100 select-none px-6 py-3.5 text-sm font-semibold',
                   header.primary ? 'w-2/5' : 'w-[15%]',
                 )}
               >

--- a/packages/overlay/src/integrations/sentry/components/Performance/Queries.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/Queries.tsx
@@ -95,7 +95,7 @@ const Queries = ({ showAll }: { showAll: boolean }) => {
     }
   }, [showAll, sort]);
 
-  if (queriesData) {
+  if (queriesData && queriesData.length) {
     return (
       <table className="divide-primary-700 w-full table-fixed divide-y">
         <thead>

--- a/packages/overlay/src/integrations/sentry/components/Performance/QuerySummary.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/QuerySummary.tsx
@@ -73,7 +73,7 @@ const QuerySummary = ({ showAll }: { showAll: boolean }) => {
     );
   }, [showAll, sort]);
 
-  if (filteredDBSpans && type) {
+  if (type && filteredDBSpans && filteredDBSpans.length) {
     return (
       <>
         <Breadcrumbs

--- a/packages/overlay/src/integrations/sentry/components/Performance/QuerySummary.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/QuerySummary.tsx
@@ -105,7 +105,7 @@ const QuerySummary = ({ showAll }: { showAll: boolean }) => {
                 >
                   <div
                     className={classNames(
-                      'flex cursor-pointer items-center gap-1',
+                      'flex cursor-pointer select-none items-center gap-1',
                       header.primary ? 'justify-start' : 'justify-end',
                     )}
                     onClick={() => toggleSortOrder(header.sortKey)}

--- a/packages/overlay/src/integrations/sentry/components/Performance/Resources.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/Resources.tsx
@@ -131,7 +131,7 @@ const Resources = ({ showAll }: { showAll: boolean }) => {
               >
                 <div
                   className={classNames(
-                    'flex cursor-pointer items-center gap-1',
+                    'flex cursor-pointer select-none items-center gap-1',
                     header.primary ? 'justify-start' : 'justify-end',
                   )}
                   onClick={() => toggleSortOrder(header.sortKey)}

--- a/packages/overlay/src/integrations/sentry/components/Performance/Resources.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/Resources.tsx
@@ -115,7 +115,7 @@ const Resources = ({ showAll }: { showAll: boolean }) => {
     }
   }, [sort, showAll]);
 
-  if (resources) {
+  if (resources && resources.length) {
     return (
       <table className="divide-primary-700 w-full table-fixed divide-y">
         <thead>

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/PerformanceChart.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/PerformanceChart.tsx
@@ -1,0 +1,263 @@
+import { useRef, useState } from 'react';
+import RingChart from '~/components/RingChart';
+import classNames from '~/lib/classNames';
+import { WebVitals } from '../../../constants';
+import useMouseTracking from '../../../hooks/useMouseTracking';
+
+type Coordinates = {
+  x: number;
+  y: number;
+};
+
+type WebVitalsLabelCoordinates = {
+  [p in WebVitals]?: Coordinates;
+};
+
+type WebVitalLabelProps = {
+  coordinates: Coordinates;
+  inPerformanceWidget?: boolean;
+  webVital: WebVitals;
+  labelCoordinates?: WebVitalsLabelCoordinates;
+};
+
+function WebVitalLabel({ webVital, coordinates, labelCoordinates = {} }: WebVitalLabelProps) {
+  const xOffset = labelCoordinates?.[webVital]?.x ?? 0;
+  const yOffset = labelCoordinates?.[webVital]?.y ?? 0;
+  return (
+    <text
+      className="fill-primary-200 stroke-primary-200 uppercase"
+      x={coordinates.x + xOffset}
+      y={coordinates.y + yOffset}
+    >
+      {webVital}
+    </text>
+  );
+}
+
+type MetricScoreProps = {
+  fcpScore: number;
+  lcpScore: number;
+  clsScore: number;
+  fidScore: number;
+  ttfbScore: number;
+};
+type MetricWeightsProps = {
+  fcp: number;
+  lcp: number;
+  cls: number;
+  fid: number;
+  ttfb: number;
+};
+type PerformanceChartProps = {
+  metricScore: MetricScoreProps;
+  metricWeights: MetricWeightsProps;
+  totalScore?: number;
+  size?: number;
+  barWidth?: number;
+  left?: number;
+  top?: number;
+};
+
+const PerformanceChart = ({
+  metricScore,
+  metricWeights,
+  totalScore,
+  size = 200,
+  barWidth = 25,
+  left = 40,
+  top = 25,
+}: PerformanceChartProps) => {
+  const [webVitalTooltip, setWebVitalTooltip] = useState<WebVitals | null>(null);
+  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
+  const containerRef = useRef<HTMLDivElement>(null);
+  const mouseTrackingProps = useMouseTracking({
+    elem: containerRef,
+    onPositionChange: args => {
+      if (args) {
+        const { left, top } = args;
+        setMousePosition({ x: left, y: top });
+      }
+    },
+  });
+
+  function calculateLabelCoordinates(
+    size: number,
+    x: number,
+    y: number,
+    barWidth: number,
+    metricWeights: {
+      [key in WebVitals]: number;
+    },
+    labelWidthPadding: number,
+    labelHeightPadding: number,
+    radiusPadding: number,
+  ) {
+    const radius = size / 2 + barWidth + radiusPadding;
+    const center = {
+      x: x + size / 2 - labelWidthPadding / 2,
+      y: y + size / 2 + labelHeightPadding / 2,
+    };
+    const sumMaxValues = Object.values(metricWeights).reduce((acc, val) => acc + val, 0);
+    const BASE_ANGLE = -90;
+    const weightToAngle = (weight: number) => (weight / sumMaxValues) * 360;
+    const [lcpAngle, fcpAngle, fidAngle, clsAngle, ttfbAngle] = [
+      metricWeights.lcp,
+      metricWeights.fcp,
+      metricWeights.fid,
+      metricWeights.cls,
+      metricWeights.ttfb,
+    ].map(weightToAngle);
+    const lcpX = center.x + radius * Math.cos(((BASE_ANGLE + lcpAngle / 2) * Math.PI) / 180);
+    const lcpY = center.y + radius * Math.sin(((BASE_ANGLE + lcpAngle / 2) * Math.PI) / 180);
+    const fcpX = center.x + radius * Math.cos(((BASE_ANGLE + lcpAngle + fcpAngle / 2) * Math.PI) / 180);
+    const fcpY = center.y + radius * Math.sin(((BASE_ANGLE + lcpAngle + fcpAngle / 2) * Math.PI) / 180);
+    const fidX = center.x + radius * Math.cos(((BASE_ANGLE + lcpAngle + fcpAngle + fidAngle / 2) * Math.PI) / 180);
+    const fidY = center.y + radius * Math.sin(((BASE_ANGLE + lcpAngle + fcpAngle + fidAngle / 2) * Math.PI) / 180);
+    const clsX =
+      center.x + radius * Math.cos(((BASE_ANGLE + lcpAngle + fcpAngle + fidAngle + clsAngle / 2) * Math.PI) / 180);
+    const clsY =
+      center.y + radius * Math.sin(((BASE_ANGLE + lcpAngle + fcpAngle + fidAngle + clsAngle / 2) * Math.PI) / 180);
+    // Padding hack for now since ttfb label is longer than the others
+    const ttfbX =
+      center.x -
+      12 +
+      radius * Math.cos(((BASE_ANGLE + lcpAngle + fcpAngle + fidAngle + clsAngle + ttfbAngle / 2) * Math.PI) / 180);
+    const ttfbY =
+      center.y +
+      radius * Math.sin(((BASE_ANGLE + lcpAngle + fcpAngle + fidAngle + clsAngle + ttfbAngle / 2) * Math.PI) / 180);
+
+    return {
+      lcpX,
+      lcpY,
+      fcpX,
+      fcpY,
+      fidX,
+      fidY,
+      clsX,
+      clsY,
+      ttfbX,
+      ttfbY,
+    };
+  }
+
+  const labelWidthPadding = 28;
+  const labelHeightPadding = 14;
+  const radiusPadding = 4;
+  const { lcpX, lcpY, fcpX, fcpY, fidX, fidY, clsX, clsY, ttfbX, ttfbY } = calculateLabelCoordinates(
+    size,
+    left,
+    top,
+    barWidth,
+    metricWeights,
+    labelWidthPadding,
+    labelHeightPadding,
+    radiusPadding,
+  );
+  return (
+    <div ref={containerRef} {...mouseTrackingProps}>
+      {webVitalTooltip && (
+        <div
+          className={classNames(
+            'bg-primary-900 border-primary-400 absolute flex w-40 items-center justify-between rounded-lg border p-3 shadow-lg',
+          )}
+          style={{
+            transform: `translate3d(${mousePosition.x - 100}px, ${mousePosition.y - 74}px, 0px)`,
+          }}
+        >
+          <span className="text-primary-200">{`${webVitalTooltip.toUpperCase()} Score:`}</span>
+          <span className="text-primary-200 font-semibold">{metricScore[`${webVitalTooltip}Score`]}</span>
+        </div>
+      )}
+
+      <svg height={size + 3 * top} width={size + 3 * left}>
+        <>
+          {metricWeights.lcp > 0 && (
+            <WebVitalLabel
+              webVital="lcp"
+              coordinates={{
+                x: lcpX,
+                y: lcpY,
+              }}
+            />
+          )}
+          {metricWeights.fcp > 0 && (
+            <WebVitalLabel
+              webVital="fcp"
+              coordinates={{
+                x: fcpX,
+                y: fcpY,
+              }}
+            />
+          )}
+          {metricWeights.fid > 0 && (
+            <WebVitalLabel
+              webVital="fid"
+              coordinates={{
+                x: fidX,
+                y: fidY,
+              }}
+            />
+          )}
+          {metricWeights.cls > 0 && (
+            <WebVitalLabel
+              webVital="cls"
+              coordinates={{
+                x: clsX,
+                y: clsY,
+              }}
+            />
+          )}
+          {metricWeights.ttfb > 0 && (
+            <WebVitalLabel
+              webVital="ttfb"
+              coordinates={{
+                x: ttfbX,
+                y: ttfbY,
+              }}
+            />
+          )}
+        </>
+
+        <RingChart
+          values={[
+            (metricScore.lcpScore ?? 0) * metricWeights.lcp * 0.01,
+            (metricScore.fcpScore ?? 0) * metricWeights.fcp * 0.01,
+            (metricScore.fidScore ?? 0) * metricWeights.fid * 0.01,
+            (metricScore.clsScore ?? 0) * metricWeights.cls * 0.01,
+            (metricScore.ttfbScore ?? 0) * metricWeights.ttfb * 0.01,
+          ]}
+          maxValues={[metricWeights.lcp, metricWeights.fcp, metricWeights.fid, metricWeights.cls, metricWeights.ttfb]}
+          text={totalScore}
+          size={size}
+          barWidth={barWidth}
+          segmentColors={[
+            'stroke-primary-300',
+            'stroke-primary-400',
+            'stroke-primary-500',
+            'stroke-primary-600',
+            'stroke-primary-700',
+          ]}
+          backgroundColors={[
+            'stroke-gray-400',
+            'stroke-gray-400',
+            'stroke-gray-400',
+            'stroke-gray-400',
+            'stroke-gray-400',
+          ]}
+          x={left}
+          y={top}
+          onHoverActions={[
+            () => setWebVitalTooltip('lcp'),
+            () => setWebVitalTooltip('fcp'),
+            () => setWebVitalTooltip('fid'),
+            () => setWebVitalTooltip('cls'),
+            () => setWebVitalTooltip('ttfb'),
+          ]}
+          onUnhover={() => setWebVitalTooltip(null)}
+        />
+      </svg>
+    </div>
+  );
+};
+
+export default PerformanceChart;

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/WebVitalsDetail.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/WebVitalsDetail.tsx
@@ -1,26 +1,12 @@
 import { useParams } from 'react-router-dom';
 import Breadcrumbs from '~/components/Breadcrumbs';
-import { PERFORMANCE_SCORE } from '~/integrations/sentry/constants';
+import { PERFORMANCE_SCORE_PROFILES } from '~/integrations/sentry/constants';
 import { useSentryEvents } from '~/integrations/sentry/data/useSentryEvents';
-import { SentryEventWithPerformanceData } from '~/integrations/sentry/types';
+import { MetricScoreProps, MetricWeightsProps, SentryEventWithPerformanceData } from '~/integrations/sentry/types';
 import { getFormattedDuration } from '~/integrations/sentry/utils/duration';
+import { normalizePerformanceScore } from '../../../utils/webVitals';
 import PerformanceChart from './PerformanceChart';
-import { normalizePerformanceScore } from './utils';
 
-type MetricScoreProps = {
-  fcpScore: number;
-  lcpScore: number;
-  clsScore: number;
-  fidScore: number;
-  ttfbScore: number;
-};
-type MetricWeightsProps = {
-  fcp: number;
-  lcp: number;
-  cls: number;
-  fid: number;
-  ttfb: number;
-};
 const WebVitalsDetail = () => {
   const events = useSentryEvents();
   const { page } = useParams();
@@ -30,7 +16,7 @@ const WebVitalsDetail = () => {
     .filter(event => event.event_id === page)
     .map(event => {
       const updatedEvent = { ...event };
-      normalizePerformanceScore(updatedEvent, PERFORMANCE_SCORE);
+      normalizePerformanceScore(updatedEvent, PERFORMANCE_SCORE_PROFILES);
       measurementEvents.push(updatedEvent as unknown as SentryEventWithPerformanceData);
     });
 

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/WebVitalsDetail.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/WebVitalsDetail.tsx
@@ -1,0 +1,136 @@
+import { useParams } from 'react-router-dom';
+import Breadcrumbs from '~/components/Breadcrumbs';
+import { PERFORMANCE_SCORE } from '~/integrations/sentry/constants';
+import { useSentryEvents } from '~/integrations/sentry/data/useSentryEvents';
+import { SentryEventWithPerformanceData } from '~/integrations/sentry/types';
+import { getFormattedDuration } from '~/integrations/sentry/utils/duration';
+import PerformanceChart from './PerformanceChart';
+import { normalizePerformanceScore } from './utils';
+
+type MetricScoreProps = {
+  fcpScore: number;
+  lcpScore: number;
+  clsScore: number;
+  fidScore: number;
+  ttfbScore: number;
+};
+type MetricWeightsProps = {
+  fcp: number;
+  lcp: number;
+  cls: number;
+  fid: number;
+  ttfb: number;
+};
+const WebVitalsDetail = () => {
+  const events = useSentryEvents();
+  const { page } = useParams();
+  const measurementEvents: SentryEventWithPerformanceData[] = [];
+
+  events
+    .filter(event => event.event_id === page)
+    .map(event => {
+      const updatedEvent = { ...event };
+      normalizePerformanceScore(updatedEvent, PERFORMANCE_SCORE);
+      measurementEvents.push(updatedEvent as unknown as SentryEventWithPerformanceData);
+    });
+
+  if (page && measurementEvents.length) {
+    const metricScore: MetricScoreProps = {
+      fcpScore: Math.trunc(measurementEvents[0].measurements['score.fcp'].value * 100),
+      lcpScore: Math.trunc(measurementEvents[0].measurements['score.lcp'].value * 100),
+      fidScore: Math.trunc(measurementEvents[0].measurements['score.fid'].value * 100),
+      clsScore: Math.trunc(measurementEvents[0].measurements['score.cls'].value * 100),
+      ttfbScore: Math.trunc(measurementEvents[0].measurements['score.ttfb'].value * 100),
+    };
+
+    const metricWeights: MetricWeightsProps = {
+      fcp: Math.trunc(measurementEvents[0].measurements['score.weight.fcp'].value * 100),
+      lcp: Math.trunc(measurementEvents[0].measurements['score.weight.lcp'].value * 100),
+      fid: Math.trunc(measurementEvents[0].measurements['score.weight.fid'].value * 100),
+      cls: Math.trunc(measurementEvents[0].measurements['score.weight.cls'].value * 100),
+      ttfb: Math.trunc(measurementEvents[0].measurements['score.weight.ttfb'].value * 100),
+    };
+
+    const totalScore: number = Math.trunc(measurementEvents[0].measurements['score.total'].value * 100);
+
+    const projectScoreHeaders = [
+      {
+        id: 'fcpScore',
+        description: 'First Contentful Paint',
+        label: 'FCP',
+        score: measurementEvents[0].measurements?.fcp
+          ? getFormattedDuration(measurementEvents[0].measurements.fcp.value)
+          : '-',
+      },
+      {
+        id: 'lcpScore',
+        description: 'Largest Contentful Paint',
+        label: 'LCP',
+        score: measurementEvents[0].measurements?.lcp
+          ? getFormattedDuration(measurementEvents[0].measurements.lcp.value)
+          : '-',
+      },
+      {
+        id: 'fidScore',
+        description: 'First Input Delay',
+        label: 'FID',
+        score: measurementEvents[0].measurements?.fid
+          ? getFormattedDuration(measurementEvents[0].measurements.fid.value)
+          : '-',
+      },
+      {
+        id: 'clsScore',
+        description: 'Cumulative Layout Shift',
+        label: 'CLS',
+        score: measurementEvents[0].measurements?.cls
+          ? getFormattedDuration(measurementEvents[0].measurements.cls.value)
+          : '-',
+      },
+      {
+        id: 'ttfbScore',
+        description: 'Time to First Byte',
+        label: 'TTFB',
+        score: measurementEvents[0].measurements?.ttfb
+          ? getFormattedDuration(measurementEvents[0].measurements.ttfb.value)
+          : '-',
+      },
+    ];
+
+    return (
+      <>
+        <Breadcrumbs
+          crumbs={[
+            {
+              id: 'webVitals',
+              label: 'Web Vitals',
+              link: true,
+              to: '/performance/webvitals',
+            },
+            {
+              id: 'performanceSummary',
+              label: 'Performance Summary',
+              link: false,
+            },
+          ]}
+        />
+        <div className="w-full px-6">
+          <div className="flex w-full items-center justify-center p-6">
+            <PerformanceChart totalScore={totalScore} metricWeights={metricWeights} metricScore={metricScore} />
+          </div>
+          <div className="flex w-full flex-wrap justify-center gap-2">
+            {projectScoreHeaders.map(header => (
+              <div className="bg-primary-900 border-primary-400 flex w-80 flex-col items-center gap-4 rounded-lg border p-2 shadow-lg">
+                <span className="text-primary-300 text-base font-semibold">{header.label}</span>
+                <span className="text-primary-300 text-sm font-light">{header.description}</span>
+                <h2 className="text-primary-300 text-lg font-bold">{header.score ?? '-'}</h2>
+              </div>
+            ))}
+          </div>
+        </div>
+      </>
+    );
+  }
+  return <div className="text-primary-300 px-6 py-4">Invalid Data. Please try again.</div>;
+};
+
+export default WebVitalsDetail;

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/WebVitalsDetail.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/WebVitalsDetail.tsx
@@ -105,7 +105,10 @@ const WebVitalsDetail = () => {
           </div>
           <div className="flex w-full flex-wrap justify-center gap-2">
             {projectScoreHeaders.map(header => (
-              <div className="bg-primary-900 border-primary-400 flex w-80 flex-col items-center gap-4 rounded-lg border p-2 shadow-lg">
+              <div
+                key={header.id}
+                className="bg-primary-900 border-primary-400 flex w-80 flex-col items-center gap-4 rounded-lg border p-2 shadow-lg"
+              >
                 <span className="text-primary-300 text-base font-semibold">{header.label}</span>
                 <span className="text-primary-300 text-sm font-light">{header.description}</span>
                 <h2 className="text-primary-300 text-lg font-bold">{header.score ?? '-'}</h2>

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/index.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/index.tsx
@@ -2,12 +2,12 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { ReactComponent as Sort } from '~/assets/sort.svg';
 import { ReactComponent as SortDown } from '~/assets/sortDown.svg';
-import { PERFORMANCE_SCORE, WEB_VITALS_HEADERS, WEB_VITALS_SORT_KEYS } from '~/integrations/sentry/constants';
+import { PERFORMANCE_SCORE_PROFILES, WEB_VITALS_HEADERS, WEB_VITALS_SORT_KEYS } from '~/integrations/sentry/constants';
 import { useSentryEvents } from '~/integrations/sentry/data/useSentryEvents';
 import { SentryEventWithPerformanceData } from '~/integrations/sentry/types';
 import { getFormattedDuration } from '~/integrations/sentry/utils/duration';
 import classNames from '~/lib/classNames';
-import { normalizePerformanceScore } from './utils';
+import { normalizePerformanceScore } from '../../../utils/webVitals';
 
 const WebVitals = ({ showAll }: { showAll: boolean }) => {
   const events = useSentryEvents();
@@ -67,14 +67,18 @@ const WebVitals = ({ showAll }: { showAll: boolean }) => {
     for (const event of events) {
       if (
         event.measurements &&
-        (event.measurements['fcp'] ||
-          event.measurements['cls'] ||
-          event.measurements['ttfb'] ||
-          event.measurements['lcp'] ||
-          event.measurements['fid'])
+        event?.contexts?.trace?.op === 'pageload'
+        // TODO: Skipping this check because of not getting all required metrics
+        // && !PERFORMANCE_SCORE_PROFILES.profiles[0].scoreComponents.some(c => {
+        //   return (
+        //     !Object.prototype.hasOwnProperty.call(event.measurements, c.measurement) &&
+        //     Math.abs(c.weight) >= Number.EPSILON &&
+        //     !c.optional
+        //   );
+        // })
       ) {
         const updatedEvent = { ...event };
-        normalizePerformanceScore(updatedEvent, PERFORMANCE_SCORE);
+        normalizePerformanceScore(updatedEvent, PERFORMANCE_SCORE_PROFILES);
         _measurementEvents.push(updatedEvent as unknown as SentryEventWithPerformanceData);
       }
     }

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/index.tsx
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/index.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { ReactComponent as Sort } from '~/assets/sort.svg';
+import { ReactComponent as SortDown } from '~/assets/sortDown.svg';
+import { PERFORMANCE_SCORE, WEB_VITALS_HEADERS, WEB_VITALS_SORT_KEYS } from '~/integrations/sentry/constants';
+import { useSentryEvents } from '~/integrations/sentry/data/useSentryEvents';
+import { SentryEventWithPerformanceData } from '~/integrations/sentry/types';
+import { getFormattedDuration } from '~/integrations/sentry/utils/duration';
+import classNames from '~/lib/classNames';
+import { normalizePerformanceScore } from './utils';
+
+const WebVitals = ({ showAll }: { showAll: boolean }) => {
+  const events = useSentryEvents();
+  const [measurementEvents, setMeasurementEvents] = useState<SentryEventWithPerformanceData[]>([]);
+  const [sort, setSort] = useState({
+    active: WEB_VITALS_SORT_KEYS.score,
+    asc: false,
+  });
+
+  const toggleSortOrder = (type: string) => {
+    if (sort.active === type) {
+      setSort(prev => ({
+        active: type,
+        asc: !prev.asc,
+      }));
+    } else {
+      setSort({
+        active: type,
+        asc: false,
+      });
+    }
+  };
+
+  const compareEvents = (a: SentryEventWithPerformanceData, b: SentryEventWithPerformanceData) => {
+    switch (sort.active) {
+      case WEB_VITALS_SORT_KEYS.pages: {
+        if (a.transaction && b.transaction && a.transaction < b.transaction) return -1;
+        if (a.transaction && b.transaction && a.transaction > b.transaction) return 1;
+        return 0;
+      }
+      case WEB_VITALS_SORT_KEYS.lcp: {
+        return a.measurements['score.lcp'].value - b.measurements['score.lcp'].value;
+      }
+      case WEB_VITALS_SORT_KEYS.fid: {
+        return a.measurements['score.fid'].value - b.measurements['score.fid'].value;
+      }
+      case WEB_VITALS_SORT_KEYS.fcp: {
+        return a.measurements['score.fcp'].value - b.measurements['score.fcp'].value;
+      }
+      case WEB_VITALS_SORT_KEYS.cls: {
+        return a.measurements['score.cls'].value - b.measurements['score.cls'].value;
+      }
+      case WEB_VITALS_SORT_KEYS.ttfb: {
+        return a.measurements['score.ttfb'].value - b.measurements['score.ttfb'].value;
+      }
+      case WEB_VITALS_SORT_KEYS.score: {
+        return a.measurements['score.total'].value - b.measurements['score.total'].value;
+      }
+      default: {
+        return a.measurements['score.total'].value - b.measurements['score.total'].value;
+      }
+    }
+  };
+
+  useEffect(() => {
+    const _measurementEvents = [];
+    for (const event of events) {
+      if (
+        event.measurements &&
+        (event.measurements['fcp'] ||
+          event.measurements['cls'] ||
+          event.measurements['ttfb'] ||
+          event.measurements['lcp'] ||
+          event.measurements['fid'])
+      ) {
+        const updatedEvent = { ...event };
+        normalizePerformanceScore(updatedEvent, PERFORMANCE_SCORE);
+        _measurementEvents.push(updatedEvent as unknown as SentryEventWithPerformanceData);
+      }
+    }
+    setMeasurementEvents(
+      _measurementEvents.sort((a, b) => {
+        return sort.asc ? compareEvents(a, b) : compareEvents(b, a);
+      }),
+    );
+  }, [showAll, sort]);
+
+  if (measurementEvents && measurementEvents.length) {
+    return (
+      <>
+        <table className="divide-primary-700 w-full table-fixed divide-y">
+          <thead>
+            <tr>
+              {WEB_VITALS_HEADERS.map(header => (
+                <th
+                  key={header.id}
+                  scope="col"
+                  className={classNames(
+                    'text-primary-100 px-6 py-3.5 text-sm font-semibold',
+                    header.primary ? 'w-2/5' : 'w-[15%]',
+                  )}
+                >
+                  <div
+                    className={classNames(
+                      'flex cursor-pointer select-none items-center gap-1',
+                      header.primary ? 'justify-start' : 'justify-end',
+                    )}
+                    onClick={() => toggleSortOrder(header.sortKey)}
+                  >
+                    {header.title}
+                    {sort.active === header.sortKey ? (
+                      <SortDown
+                        width={12}
+                        height={12}
+                        className={classNames(
+                          'fill-primary-300',
+                          sort.asc ? '-translate-y-0.5 rotate-0' : 'translate-y-0.5 rotate-180',
+                        )}
+                      />
+                    ) : (
+                      <Sort width={12} height={12} className="stroke-primary-300" />
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {measurementEvents.map(event => (
+              <tr key={event.event_id} className="hover:bg-primary-900">
+                <td className="text-primary-200 w-2/5 truncate whitespace-nowrap px-6 py-4 text-left text-sm font-medium">
+                  <Link className="truncate hover:underline" to={`/performance/webvitals/${event.event_id}`}>
+                    {event.transaction}
+                  </Link>
+                </td>
+                <td className="text-primary-200 w-[15%] whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                  {event.measurements?.lcp ? getFormattedDuration(event.measurements.lcp.value) : '-'}
+                </td>
+                <td className="text-primary-200 w-[15%] whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                  {event.measurements?.fcp ? getFormattedDuration(event.measurements.fcp.value) : '-'}
+                </td>
+                <td className="text-primary-200 w-[15%] whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                  {event.measurements?.fid ? getFormattedDuration(event.measurements.fid.value) : '-'}
+                </td>
+                <td className="text-primary-200 w-[15%] whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                  {event.measurements?.cls ? event.measurements.cls.value : '-'}
+                </td>
+                <td className="text-primary-200 w-[15%] whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                  {event.measurements?.ttfb ? getFormattedDuration(event.measurements.ttfb.value) : '-'}
+                </td>
+                <td className="text-primary-200 w-[15%] whitespace-nowrap px-6 py-4 text-right text-sm font-medium">
+                  {event.measurements['score.total']?.value
+                    ? Math.trunc(event.measurements['score.total'].value * 100)
+                    : '-'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </>
+    );
+  }
+  return <div className="text-primary-300 px-6 py-4">No Measurements found.</div>;
+};
+export default WebVitals;

--- a/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/utils.ts
+++ b/packages/overlay/src/integrations/sentry/components/Performance/WebVitals/utils.ts
@@ -1,0 +1,171 @@
+import { SentryEvent } from '~/integrations/sentry/types';
+
+const SQRT_2 = Math.sqrt(2);
+
+// Gauss error function
+function erf(x: number): number {
+  const a1 = 0.254829592;
+  const a2 = -0.284496736;
+  const a3 = 1.421413741;
+  const a4 = -1.453152027;
+  const a5 = 1.061405429;
+  const p = 0.3275911;
+
+  const sign = x < 0 ? -1 : 1;
+  const absX = Math.abs(x);
+
+  const t = 1.0 / (1.0 + p * absX);
+  const y = 1.0 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-absX * absX);
+
+  return sign * y;
+}
+
+// Sigma function for CDF score calculation
+export function calculateCdfSigma(p10: number, p50: number): number {
+  return Math.abs(Math.log(p10) - Math.log(p50)) / (SQRT_2 * 0.9061938024368232);
+}
+
+// Calculates a log-normal CDF score based on a log-normal with a specific p10 and p50
+export function calculateCdfScore(value: number, p10: number, p50: number): number {
+  return 0.5 * (1.0 - erf((Math.log(value) - Math.log(p50)) / (SQRT_2 * calculateCdfSigma(p50, p10))));
+}
+
+interface ScoreComponent {
+  measurement: string;
+  weight: number;
+  p10: number;
+  p50: number;
+  optional?: boolean;
+}
+
+interface Profile {
+  name: string;
+  scoreComponents: ScoreComponent[];
+  condition?: {
+    op: string;
+    name: string;
+    value: string | number;
+  };
+}
+
+interface PerformanceScoreConfig {
+  profiles: Profile[];
+}
+
+// export function getPropertyByPath(obj: Record<string, any>, path: string): any {
+//   const keys = path.split('.');
+//   let result = obj;
+
+//   for (const key of keys) {
+//     if (result && result[key]) {
+//       result = result[key];
+//     } else {
+//       return undefined;
+//     }
+//   }
+
+//   return result;
+// }
+
+// export function matchCondition(condition: { op: string; name: string; value: string | number }, event: SentryEvent): boolean {
+//   const { op, name, value } = condition;
+
+//   if (op === 'eq') {
+//     const eventValue = getPropertyByPath({ event }, name);
+//     return eventValue === value;
+//   }
+
+//   return false;
+// }
+
+export function normalizePerformanceScore(
+  event: SentryEvent,
+  performanceScore: PerformanceScoreConfig | undefined,
+): void {
+  if (!performanceScore) {
+    return;
+  }
+
+  for (const profile of performanceScore.profiles) {
+    // TODO: To check a matching condition as done in relay.
+    // const condition = profile.condition;
+    // if (condition && !matchCondition(condition, event)) {
+    //   continue;
+    // }
+
+    const measurements = event.measurements;
+
+    if (measurements) {
+      let shouldAddTotal = false;
+
+      /**
+       *  TODO: to not calculate the performance score if required measurement metrics are not present.
+       *  Commenting right now because we are not getting all metrics always
+       * */
+
+      // if (
+      //   profile.scoreComponents.some(c => {
+      //     return (
+      //       !Object.prototype.hasOwnProperty.call(measurements, c.measurement) &&
+      //       Math.abs(c.weight) >= Number.EPSILON &&
+      //       !c.optional
+      //     );
+      //   })
+      // ) {
+      //   break;
+      // }
+
+      let scoreTotal = 0.0;
+      let weightTotal = 0.0;
+
+      for (const component of profile.scoreComponents) {
+        if (component.optional && !Object.prototype.hasOwnProperty.call(measurements, component.measurement)) {
+          continue;
+        }
+
+        weightTotal += component.weight;
+      }
+
+      if (Math.abs(weightTotal) < Number.EPSILON) {
+        break;
+      }
+
+      for (const component of profile.scoreComponents) {
+        let normalizedComponentWeight = 0.0;
+
+        if (Object.prototype.hasOwnProperty.call(measurements, component.measurement)) {
+          normalizedComponentWeight = component.weight / weightTotal;
+          const value = measurements[component.measurement].value;
+          const cdf = calculateCdfScore(Math.max(0.0, value), component.p10, component.p50);
+          const componentScore = cdf * normalizedComponentWeight;
+          scoreTotal += componentScore;
+          shouldAddTotal = true;
+
+          measurements[`score.${component.measurement}`] = {
+            value: cdf,
+            unit: 'ratio',
+          };
+        } else {
+          measurements[`score.${component.measurement}`] = {
+            value: 0,
+            unit: 'ratio',
+          };
+        }
+
+        measurements[`score.weight.${component.measurement}`] = {
+          value: normalizedComponentWeight,
+          unit: 'ratio',
+        };
+      }
+
+      if (shouldAddTotal) {
+        measurements['score.total'] = {
+          value: scoreTotal,
+          unit: 'ratio',
+        };
+      }
+
+      break;
+    }
+  }
+}

--- a/packages/overlay/src/integrations/sentry/constants.ts
+++ b/packages/overlay/src/integrations/sentry/constants.ts
@@ -78,3 +78,115 @@ export const QUERY_SUMMARY_HEADERS = [
     sortKey: QUERY_SUMMARY_SORT_KEYS.timeSpent,
   },
 ];
+
+export const WEB_VITALS_SORT_KEYS = {
+  pages: 'Pages',
+  lcp: 'LCP',
+  fcp: 'FCP',
+  fid: 'FID',
+  cls: 'CLS',
+  ttfb: 'TTFB',
+  score: 'PERFORMANCE_SCORE',
+};
+
+export const WEB_VITALS_HEADERS = [
+  {
+    id: 'pages',
+    title: 'Pages',
+    sortKey: WEB_VITALS_SORT_KEYS.pages,
+    primary: true,
+  },
+  {
+    id: 'lcp',
+    title: 'LCP',
+    sortKey: WEB_VITALS_SORT_KEYS.lcp,
+  },
+  {
+    id: 'fcp',
+    title: 'FCP',
+    sortKey: WEB_VITALS_SORT_KEYS.fcp,
+  },
+  {
+    id: 'fid',
+    title: 'FID',
+    sortKey: WEB_VITALS_SORT_KEYS.fid,
+  },
+  {
+    id: 'cls',
+    title: 'CLS',
+    sortKey: WEB_VITALS_SORT_KEYS.cls,
+  },
+  {
+    id: 'ttfb',
+    title: 'TTFB',
+    sortKey: WEB_VITALS_SORT_KEYS.ttfb,
+  },
+  {
+    id: 'score',
+    title: 'Perf Score',
+    sortKey: WEB_VITALS_SORT_KEYS.score,
+  },
+];
+
+export type WebVitals = 'lcp' | 'fcp' | 'cls' | 'ttfb' | 'fid';
+
+export const PERFORMANCE_SCORE = {
+  profiles: [
+    {
+      name: 'Chrome',
+      scoreComponents: [
+        { measurement: 'fcp', weight: 0.15, p10: 900.0, p50: 1600.0, optional: false },
+        { measurement: 'lcp', weight: 0.3, p10: 1200.0, p50: 2400.0, optional: false },
+        { measurement: 'fid', weight: 0.3, p10: 100.0, p50: 300.0, optional: true },
+        { measurement: 'cls', weight: 0.15, p10: 0.1, p50: 0.25, optional: false },
+        { measurement: 'ttfb', weight: 0.1, p10: 200.0, p50: 400.0, optional: false },
+      ],
+      condition: { op: 'eq', name: 'event.contexts.browser.name', value: 'Chrome' },
+    },
+    // TODO: Currently not getting browser data in events, so made these comments and sticked to chrome always.
+    // {
+    //   "name": "Firefox",
+    //   "scoreComponents": [
+    //     {"measurement": "fcp", "weight": 0.15, "p10": 900.0, "p50": 1600.0, "optional": false},
+    //     {"measurement": "lcp", "weight": 0.0, "p10": 1200.0, "p50": 2400.0, "optional": false},
+    //     {"measurement": "fid", "weight": 0.30, "p10": 100.0, "p50": 300.0, "optional": true},
+    //     {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": false},
+    //     {"measurement": "ttfb", "weight": 0.10, "p10": 200.0, "p50": 400.0, "optional": false}
+    //   ],
+    //   "condition": {"op": "eq", "name": "event.contexts.browser.name", "value": "Firefox"}
+    // },
+    // {
+    //   "name": "Safari",
+    //   "scoreComponents": [
+    //     {"measurement": "fcp", "weight": 0.15, "p10": 900.0, "p50": 1600.0, "optional": false},
+    //     {"measurement": "lcp", "weight": 0.0, "p10": 1200.0, "p50": 2400.0, "optional": false},
+    //     {"measurement": "fid", "weight": 0.0, "p10": 100.0, "p50": 300.0, "optional": true},
+    //     {"measurement": "cls", "weight": 0.0, "p10": 0.1, "p50": 0.25, "optional": false},
+    //     {"measurement": "ttfb", "weight": 0.10, "p10": 200.0, "p50": 400.0, "optional": false}
+    //   ],
+    //   "condition": {"op": "eq", "name": "event.contexts.browser.name", "value": "Safari"}
+    // },
+    // {
+    //   "name": "Edge",
+    //   "scoreComponents": [
+    //     {"measurement": "fcp", "weight": 0.15, "p10": 900.0, "p50": 1600.0, "optional": false},
+    //     {"measurement": "lcp", "weight": 0.30, "p10": 1200.0, "p50": 2400.0, "optional": false},
+    //     {"measurement": "fid", "weight": 0.30, "p10": 100.0, "p50": 300.0, "optional": true},
+    //     {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": false},
+    //     {"measurement": "ttfb", "weight": 0.10, "p10": 200.0, "p50": 400.0, "optional": false}
+    //   ],
+    //   "condition": {"op": "eq", "name": "event.contexts.browser.name", "value": "Edge"}
+    // },
+    // {
+    //   "name": "Opera",
+    //   "scoreComponents": [
+    //     {"measurement": "fcp", "weight": 0.15, "p10": 900.0, "p50": 1600.0, "optional": false},
+    //     {"measurement": "lcp", "weight": 0.30, "p10": 1200.0, "p50": 2400.0, "optional": false},
+    //     {"measurement": "fid", "weight": 0.30, "p10": 100.0, "p50": 300.0, "optional": true},
+    //     {"measurement": "cls", "weight": 0.15, "p10": 0.1, "p50": 0.25, "optional": false},
+    //     {"measurement": "ttfb", "weight": 0.10, "p10": 200.0, "p50": 400.0, "optional": false}
+    //   ],
+    //   "condition": {"op": "eq", "name": "event.contexts.browser.name", "value": "Opera"}
+    // }
+  ],
+};

--- a/packages/overlay/src/integrations/sentry/constants.ts
+++ b/packages/overlay/src/integrations/sentry/constants.ts
@@ -86,7 +86,7 @@ export const WEB_VITALS_SORT_KEYS = {
   fid: 'FID',
   cls: 'CLS',
   ttfb: 'TTFB',
-  score: 'PERFORMANCE_SCORE',
+  score: 'PERFORMANCE_TOTAL_SCORE',
 };
 
 export const WEB_VITALS_HEADERS = [
@@ -130,7 +130,7 @@ export const WEB_VITALS_HEADERS = [
 
 export type WebVitals = 'lcp' | 'fcp' | 'cls' | 'ttfb' | 'fid';
 
-export const PERFORMANCE_SCORE = {
+export const PERFORMANCE_SCORE_PROFILES = {
   profiles: [
     {
       name: 'Chrome',

--- a/packages/overlay/src/integrations/sentry/hooks/useMouseTracking.ts
+++ b/packages/overlay/src/integrations/sentry/hooks/useMouseTracking.ts
@@ -1,0 +1,100 @@
+import { DOMAttributes, MouseEvent, RefObject, useCallback, useRef } from 'react';
+type CallbackArgs = { height: number; left: number; top: number; width: number };
+
+type Opts<T extends Element> = {
+  elem: RefObject<T>;
+  onPositionChange: (args: undefined | CallbackArgs) => void;
+} & DOMAttributes<T>;
+
+class AbortError extends Error {}
+function getBoundingRect(elem: Element, { signal }: { signal: AbortSignal }): Promise<DOMRectReadOnly> {
+  return new Promise((resolve, reject) => {
+    if (signal.aborted) {
+      reject(new AbortError());
+    }
+
+    const abortHandler = () => {
+      reject(new AbortError());
+    };
+
+    const observer = new IntersectionObserver(entries => {
+      for (const entry of entries) {
+        const bounds = entry.boundingClientRect;
+        resolve(bounds);
+        signal.removeEventListener('abort', abortHandler);
+      }
+      observer.disconnect();
+    });
+    signal.addEventListener('abort', abortHandler);
+    observer.observe(elem);
+  });
+}
+function useMouseTracking<T extends Element>({
+  elem,
+  onPositionChange,
+  onMouseEnter,
+  onMouseMove,
+  onMouseLeave,
+  ...rest
+}: Opts<T>) {
+  const controller = useRef<AbortController>(new AbortController());
+
+  const handlePositionChange = useCallback(
+    async (e: MouseEvent<T>) => {
+      if (!elem.current) {
+        onPositionChange(undefined);
+        return;
+      }
+
+      try {
+        const rect = await getBoundingRect(elem.current, {
+          signal: controller.current.signal,
+        });
+        onPositionChange({
+          height: rect.height,
+          left: Math.min(e.clientX - rect.left, rect.width),
+          top: Math.min(e.clientY - rect.top, rect.height),
+          width: rect.width,
+        });
+      } catch (err) {
+        if (err instanceof AbortError) {
+          // Ignore cancelled getBoundingRect calls
+          return;
+        }
+      }
+    },
+    [onPositionChange, controller, elem],
+  );
+
+  const handleOnMouseLeave = useCallback(() => {
+    if (controller.current) {
+      controller.current.abort();
+      controller.current = new AbortController();
+    }
+
+    onPositionChange(undefined);
+  }, [onPositionChange, controller]);
+
+  return {
+    ...rest,
+    onMouseEnter: (e: MouseEvent<T>) => {
+      handlePositionChange(e);
+      onMouseEnter?.(e);
+    },
+    onMouseMove: (e: MouseEvent<T>) => {
+      // prevent outside elements from firing, for example a tooltip
+      if (!elem.current?.contains(e.target as Node)) {
+        return;
+      }
+
+      handlePositionChange(e);
+      onMouseMove?.(e);
+    },
+    onMouseLeave: (e: MouseEvent<T>) => {
+      handleOnMouseLeave();
+      onMouseLeave?.(e);
+    },
+  };
+}
+
+export default useMouseTracking;

--- a/packages/overlay/src/integrations/sentry/types.ts
+++ b/packages/overlay/src/integrations/sentry/types.ts
@@ -1,3 +1,5 @@
+import { Measurements } from '@sentry/types';
+
 export type FrameVars = {
   [key: string]: string;
 };
@@ -59,6 +61,7 @@ type CommonEventAttrs = {
   tags?: Tags;
   extra?: { [key: string]: string | number };
   sdk?: Sdk;
+  measurements?: Measurements;
 };
 
 export type Context = {
@@ -131,4 +134,59 @@ export type Sdk = {
   name: string;
   version: string;
   lastSeen: number;
+};
+
+export type SentryEventWithPerformanceData = Omit<SentryEvent, 'measurements'> & {
+  measurements: Record<
+    string,
+    {
+      value: number;
+      unit: string;
+    }
+  > & {
+    'score.total': {
+      value: number;
+      unit: string;
+    };
+    'score.fcp': {
+      value: number;
+      unit: string;
+    };
+    'score.lcp': {
+      value: number;
+      unit: string;
+    };
+    'score.fid': {
+      value: number;
+      unit: string;
+    };
+    'score.cls': {
+      value: number;
+      unit: string;
+    };
+    'score.ttfb': {
+      value: number;
+      unit: string;
+    };
+    'score.weight.fcp': {
+      value: number;
+      unit: string;
+    };
+    'score.weight.lcp': {
+      value: number;
+      unit: string;
+    };
+    'score.weight.fid': {
+      value: number;
+      unit: string;
+    };
+    'score.weight.cls': {
+      value: number;
+      unit: string;
+    };
+    'score.weight.ttfb': {
+      value: number;
+      unit: string;
+    };
+  };
 };

--- a/packages/overlay/src/integrations/sentry/types.ts
+++ b/packages/overlay/src/integrations/sentry/types.ts
@@ -190,3 +190,18 @@ export type SentryEventWithPerformanceData = Omit<SentryEvent, 'measurements'> &
     };
   };
 };
+
+export type MetricScoreProps = {
+  fcpScore: number;
+  lcpScore: number;
+  clsScore: number;
+  fidScore: number;
+  ttfbScore: number;
+};
+export type MetricWeightsProps = {
+  fcp: number;
+  lcp: number;
+  cls: number;
+  fid: number;
+  ttfb: number;
+};

--- a/packages/overlay/src/integrations/sentry/utils/duration.ts
+++ b/packages/overlay/src/integrations/sentry/utils/duration.ts
@@ -29,9 +29,9 @@ export function getSpanDurationClassName(duration: number) {
   if (duration > 100) return 'text-yellow-400';
 }
 
-export function getFormattedNumber(num: number): string {
+export function getFormattedNumber(num: number, decimalPlaces: number = 2): string {
   if (num % 1 !== 0 || (num % 1 === 0 && num.toString().includes('.'))) {
-    return num.toFixed(2);
+    return num.toFixed(decimalPlaces);
   } else {
     return num.toFixed(0);
   }


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [X] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [] I referenced issues that this PR addresses

Skipped conditions:
1. Since we are not receiving every required metric to calculate the score, we have skipped the condition that prevents the calculation of the performance score in the absence of the necessary metrics. Instead, we are calculating the score with the received metrics.
2. We are consistently using weights and conditions for the Chrome browser because we are not receiving browser information in the event data.



![Screenshot from 2024-01-25 23-30-05](https://github.com/getsentry/spotlight/assets/43654389/778b4e5a-9497-4cf9-8ae7-4d63b1671608)

![Screenshot from 2024-01-25 23-30-18](https://github.com/getsentry/spotlight/assets/43654389/7f883a40-d929-4ed8-8e4c-cdf9a014fd57)

![Screenshot from 2024-01-25 23-30-27](https://github.com/getsentry/spotlight/assets/43654389/dd176e2c-1f52-48b2-9e18-04f4ac60b7d5)

![Screenshot from 2024-01-25 23-30-52](https://github.com/getsentry/spotlight/assets/43654389/553d4f06-df54-4e92-9843-ee5f782ee7aa)



