### PR TITLE
fix(sidecar): fixed setupSidecar function to not exit the process when existing sidecar is detected.

### DIFF
--- a/.changeset/itchy-poems-accept.md
+++ b/.changeset/itchy-poems-accept.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/sidecar': patch
+---
+
+Fixed setupSidecar function to not exit the process when existing sidecar is detected.

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -298,7 +298,6 @@ export function setupSidecar({
   isSidecarRunning(sidecarPort).then(isRunning => {
     if (isRunning) {
       logger.info(`Sidecar is already running on port ${sidecarPort}`);
-      process.exit(1);
     } else {
       if (!serverInstance) {
         serverInstance = startServer(buffer, sidecarPort, basePath, incomingPayload);


### PR DESCRIPTION


<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses
 when sidecar already running, process.exit can break the code when setupSidecar is called. removed that.

#333 