### PR TITLE
fix(overlay): Fix spotlight injection on error removal.

### DIFF
--- a/.changeset/old-news-shop.md
+++ b/.changeset/old-news-shop.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fixed condition where client removes the spotlight because of some error.

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -81,6 +81,14 @@ export async function trigger(eventName: string, payload: unknown) {
   );
 }
 
+function isSpotlightInjected() {
+  const windowWithSpotlight = window as WindowWithSpotlight;
+  if (windowWithSpotlight.__spotlight && window.document.getElementById('sentry-spotlight-root')) {
+    return true;
+  }
+  return false;
+}
+
 export async function init({
   openOnInit = false,
   showTriggerButton = true,
@@ -98,10 +106,7 @@ export async function init({
 
   // We only want to intialize and inject spotlight once. If it's already
   // been initialized, we can just bail out.
-  const windowWithSpotlight = window as WindowWithSpotlight;
-  if (windowWithSpotlight.__spotlight) {
-    return;
-  }
+  if (isSpotlightInjected()) return;
 
   if (debug) {
     activateLogger();
@@ -187,4 +192,9 @@ export async function init({
       injectSpotlight();
     });
   }
+  window.addEventListener('error', () => {
+    if (!isSpotlightInjected()) {
+      injectSpotlight();
+    }
+  });
 }


### PR DESCRIPTION

<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses
Addresses the hydration error issue in Next.js by ensuring the spotlight is properly reinjected after being removed due to any error.
#339 