### PR TITLE
feat(reset): Added functionality in spotlight to reset data.

### DIFF
--- a/.changeset/itchy-mice-press.md
+++ b/.changeset/itchy-mice-press.md
@@ -1,0 +1,7 @@
+---
+'@spotlightjs/overlay': minor
+'@spotlightjs/sidecar': minor
+---
+
+1. Added a DELETE /clear API route for sidecar to wipe out all data from buffer.
+2. Added a cta in overlay to clear data(only present when sentry integration is added).

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -26,6 +26,7 @@ export default function App({
   const [isOnline, setOnline] = useState(false);
   const [triggerButtonCount, setTriggerButtonCount] = useState<NotificationCount>({ count: 0, severe: false });
   const [isOpen, setOpen] = useState(openOnInit);
+  const [reloadSpotlight, setReloadSpotlight] = useState<number>(0);
 
   useKeyPress(['ctrlKey', 'F12'], () => {
     setOpen(prev => !prev);
@@ -50,7 +51,7 @@ export default function App({
       log('useEffect cleanup');
       cleanupListeners();
     };
-  }, [integrations, sidecarUrl]);
+  }, [integrations, sidecarUrl, reloadSpotlight]);
 
   const spotlightEventTarget = getSpotlightEventTarget();
 
@@ -121,6 +122,7 @@ export default function App({
         integrationData={integrationData}
         setTriggerButtonCount={setTriggerButtonCount}
         fullPage={fullPage}
+        setReloadSpotlight={setReloadSpotlight}
       />
     </>
   );

--- a/packages/overlay/src/components/Debugger.tsx
+++ b/packages/overlay/src/components/Debugger.tsx
@@ -1,8 +1,16 @@
+import { useContext } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { ReactComponent as Logo } from '~/assets/glyph.svg';
 import { Integration, IntegrationData } from '~/integrations/integration';
+import sentryDataCache from '~/integrations/sentry/data/sentryDataCache';
+import { SentryEventsContext } from '~/integrations/sentry/data/sentryEventsContext';
+import { getNativeFetchImplementation } from '~/integrations/sentry/sentry-integration';
 import { NotificationCount } from '~/types';
 import classNames from '../lib/classNames';
 import Overview from './Overview';
+
+// TODO: To expose the port and sidecar url across the app instead of hardcoded
+const PORT = 8969;
 
 function FullscreenBlur({
   isOpen,
@@ -40,6 +48,7 @@ export default function Debugger({
   isOnline,
   setTriggerButtonCount: setNotificationCount,
   fullPage,
+  setReloadSpotlight,
 }: {
   integrations: Integration[];
   isOpen: boolean;
@@ -48,7 +57,31 @@ export default function Debugger({
   isOnline: boolean;
   setTriggerButtonCount: (count: NotificationCount) => void;
   fullPage: boolean;
+  setReloadSpotlight: React.Dispatch<React.SetStateAction<number>>;
 }) {
+  const isSentryIntegrationAdded = integrations.some(integration => integration.name === 'sentry');
+  const { setEvents } = useContext(SentryEventsContext);
+  const navigate = useNavigate();
+
+  const clearEvents = () => {
+    const sidecarUrl = `http://localhost:${PORT}/clear`;
+    const makeFetch = getNativeFetchImplementation();
+    makeFetch(sidecarUrl, {
+      method: 'DELETE',
+      mode: 'cors',
+    }).catch(err => {
+      console.error(
+        `Sentry SDK can't connect to Sidecar is it running? See: https://spotlightjs.com/sidecar/npx/`,
+        err,
+      );
+    });
+
+    setEvents({ action: 'RESET', e: [] });
+    sentryDataCache.resetData();
+    navigate('/errors');
+    setReloadSpotlight(prev => prev + 1);
+  };
+
   return (
     <FullscreenBlur isOpen={isOpen} setOpen={setOpen} fullPage={fullPage}>
       <div className={classNames('spotlight-debugger', fullPage ? 'spotlight-fullscreen' : '')}>
@@ -89,6 +122,14 @@ export default function Debugger({
               </div>
             </div>
           </h1>
+          {isSentryIntegrationAdded && (
+            <button
+              className="bg-primary-950 text-primary-300 border-primary-300 hover:bg-primary-900 hover:border-primary-900 mr-1 rounded-md border px-2 py-1 hover:transition-colors"
+              onClick={() => clearEvents()}
+            >
+              Clear Events
+            </button>
+          )}
           {!fullPage && (
             <button
               className="hover:bg-primary-900 -my-1 -mr-3 cursor-pointer rounded px-3 py-1 font-mono text-2xl"

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -200,6 +200,14 @@ class SentryDataCache {
     return trace.spans.find(s => s.span_id === spanId);
   }
 
+  resetData() {
+    this.events = [];
+    this.eventIds = new Set<string>();
+    this.traces = [];
+    this.tracesById = {};
+    this.localTraceIds = new Set<string>();
+  }
+
   subscribe(...args: Subscription) {
     const id = generate_uuidv4();
     this.subscribers.set(id, args);

--- a/packages/overlay/src/integrations/sentry/data/useSentryEvents.tsx
+++ b/packages/overlay/src/integrations/sentry/data/useSentryEvents.tsx
@@ -1,6 +1,8 @@
 import { useContext } from 'react';
+import sentryDataCache from './sentryDataCache';
 import { SentryEventsContext } from './sentryEventsContext';
 
 export const useSentryEvents = () => {
-  return useContext(SentryEventsContext);
+  useContext(SentryEventsContext);
+  return sentryDataCache.getEvents();
 };


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses

#344 

1. Added a DELETE /clear API route for the sidecar to wipe out all data from the buffer.
2. Added a cta in overlay to clear data(only present when sentry integration is added).


[Screencast from 01-02-24 12:31:12 AM IST.webm](https://github.com/getsentry/spotlight/assets/43654389/f2544587-8236-4a72-8d72-f500daed0a86)
