### PR TITLE
fix(overlay): Drop interaction transactions from overlay interactions

### DIFF
--- a/.changeset/fair-dingos-hang.md
+++ b/.changeset/fair-dingos-hang.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+fix(overlay): Drop interaction transactions from overlay interactions


### PR DESCRIPTION
This PR drops experimental interaction transactions in the sentry integration's event processor if we determine that they were created from interactions (clicks) within the Spotlight overlay UI. IMO there's no reason to

1. send them to Sentry (only blows up user quota)
2. show them in Spotlight (on the contrary this isn't great UX at all)

So let's just drop these transactions/root spans for now