### PR TITLE
fix: Process webpack build

### DIFF
--- a/.changeset/sweet-mangos-knock.md
+++ b/.changeset/sweet-mangos-knock.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Define process variables for webpack builds

--- a/packages/overlay/vite.config.ts
+++ b/packages/overlay/vite.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
     svgr(),
     removeReactDevToolsMessagePlugin(),
   ],
+  define: {
+    'process.env.NODE_ENV': "'development'",
+    'process.env.JEST_WORKER_ID': 1,
+    process: {},
+  },
   resolve: {
     alias: {
       '~': resolve(__dirname, 'src'),


### PR DESCRIPTION
For some weird reason when bundling spotlight with webpack - it fails with this:

```
ERROR in ../node_modules/@spotlightjs/overlay/dist/sentry-spotlight.js 22766:11-18
Module not found: Error: Can't resolve 'process/browser' in '/home/runner/work/getsentry/sentry/node_modules/@spotlightjs/overlay/dist'
Did you mean 'browser.js'?
BREAKING CHANGE: The request 'process/browser' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve 'process/browser' in '/home/runner/work/getsentry/sentry/node_modules/@spotlightjs/overlay/dist'
  Parsed request is a module
  using description file: /home/runner/work/getsentry/sentry/node_modules/@spotlightjs/overlay/package.json (relative path: ./dist)
    Field 'browser' doesn't contain a valid alias configuration
    resolve as module
```

This fixes it by defining process.    
    