### PR TITLE
docs(mobile): Add Mobile platform snippets in new section

### DIFF
--- a/packages/website/src/components/sentryCodeBlock.mdx
+++ b/packages/website/src/components/sentryCodeBlock.mdx
@@ -95,6 +95,18 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
       options.isEnableSpotlight = BuildConfig.DEBUG;
   });
   ```
+
+  You also need to allow cleartext traffic from your emulator to the Sidecar on your host machine by adding the following to `src/debug/res/xml/network.xml`:
+  ```xml {6}
+  <?xml version="1.0" encoding="utf-8"?>
+  <network-security-config>
+      <domain-config cleartextTrafficPermitted="true">
+          <!-- Allow cleartext traffic from the emulator to the host machine -->
+          <!-- See https://developer.android.com/studio/run/emulator-networking for more details -->
+          <domain includeSubdomains="true">10.0.2.2</domain>
+      </domain-config>
+  </network-security-config>
+  ```
   </TabItem>
   <TabItem label="iOS">
   :::caution

--- a/packages/website/src/components/sentryCodeBlock.mdx
+++ b/packages/website/src/components/sentryCodeBlock.mdx
@@ -68,7 +68,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   :::caution
   Requires `sentry-dotnet` version `4.0.0` or higher.
   :::
-  ```csharp {3-6}
+  ```csharp {4-7}
   SentrySdk.Init(o =>
   {
       o.Dsn = "___DSN___";
@@ -112,7 +112,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   :::caution
   Requires `sentry-cocoa` version `8.21.0` or higher.
   :::
-  ```swift {4}
+  ```swift {3-6}
   SentrySDK.start { options in
       options.dsn = "___DSN___"
 #if DEBUG
@@ -126,7 +126,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   :::caution
   Requires `sentry-react-native` version `5.18.0` or higher.
   :::
-  ```typescript {4}
+  ```typescript {3}
   Sentry.init({
       dsn: '___DSN___',
       enableSpotlight: __DEV__,

--- a/packages/website/src/components/sentryCodeBlock.mdx
+++ b/packages/website/src/components/sentryCodeBlock.mdx
@@ -4,6 +4,8 @@ title: Sentry Setup Codeblock
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 
+### Web platforms
+
 <Tabs>
   <TabItem label="JavaScript (Browser)">
   In the Browser you don't need to set `spotlight: true`, `Spotlight.init()` will automatically detect if Sentry is available and if so, hook into the SDK.
@@ -42,7 +44,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   :::caution
   Requires `sentry/sentry` version `4.1.0` or higher.
   :::
-  ```php {4}
+  ```php {4} 
   \Sentry\init([
       'dsn' => '___DSN___',
       // You should only load this in your development environment
@@ -74,6 +76,64 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
       // You should only load this in your development environment
       o.EnableSpotlight = true;
 #endif
+  });
+  ```
+  </TabItem>
+</Tabs>
+
+### Mobile platforms
+
+<Tabs>
+  <TabItem label="Android">
+  :::caution
+  Requires `sentry-java` version `7.4.0` or higher.
+  :::
+  ```kotlin {4}
+  SentryAndroid.init(this, options -> {
+      options.setDsn("___DSN___");
+      // You should only enable this in your development environment
+      if (BuildConfig.DEBUG) {
+          options.isEnableSpotlight = true;
+      }
+  });
+  ```
+  </TabItem>
+  <TabItem label="iOS">
+  :::caution
+  Requires `sentry-cocoa` version `8.21.0` or higher.
+  :::
+  ```swift {4}
+  SentrySDK.start { options in
+      options.dsn = "___DSN___"
+      // You should only enable this in your development environment
+#if DEBUG
+      options.enableSpotlight = true
+#endif
+  }
+  ```
+  </TabItem>
+  <TabItem label="React Native">
+  :::caution
+  Requires `sentry-react-native` version `5.18.0` or higher.
+  :::
+  ```typescript {4}
+  Sentry.init({
+      dsn: '___DSN___',
+      enableSpotlight: __DEV__,
+  });
+  ```
+  </TabItem>
+  <TabItem label="Flutter">
+  :::caution
+  Requires `sentry-dart` version `7.15.0` or higher.
+  :::
+  ```dart {4}
+  await SentryFlutter.init((options) {
+      options.dsn = '___DSN___';
+      // You should only enable this in your development environment
+      if (kDebugMode) {
+          options.spotlight = Spotlight(enabled: true);
+      }
   });
   ```
   </TabItem>

--- a/packages/website/src/components/sentryCodeBlock.mdx
+++ b/packages/website/src/components/sentryCodeBlock.mdx
@@ -92,9 +92,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   SentryAndroid.init(this, options -> {
       options.setDsn("___DSN___");
       // You should only enable this in your development environment
-      if (BuildConfig.DEBUG) {
-          options.isEnableSpotlight = true;
-      }
+      options.isEnableSpotlight = BuildConfig.DEBUG;
   });
   ```
   </TabItem>
@@ -105,8 +103,8 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   ```swift {4}
   SentrySDK.start { options in
       options.dsn = "___DSN___"
-      // You should only enable this in your development environment
 #if DEBUG
+      // You should only enable this in your development environment
       options.enableSpotlight = true
 #endif
   }
@@ -131,9 +129,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   await SentryFlutter.init((options) {
       options.dsn = '___DSN___';
       // You should only enable this in your development environment
-      if (kDebugMode) {
-          options.spotlight = Spotlight(enabled: true);
-      }
+      options.spotlight = Spotlight(enabled: kDebugMode);
   });
   ```
   </TabItem>

--- a/packages/website/src/components/sentryCodeBlockMobile.mdx
+++ b/packages/website/src/components/sentryCodeBlockMobile.mdx
@@ -1,0 +1,71 @@
+---
+title: Sentry Setup Codeblock Mobile platforms
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+### Mobile platforms
+
+<Tabs>
+  <TabItem label="Android">
+  :::caution
+  Requires `sentry-java` version `7.4.0` or higher.
+  :::
+  ```kotlin {4}
+  SentryAndroid.init(this, options -> {
+      options.setDsn("___DSN___");
+      // You should only enable this in your development environment
+      options.isEnableSpotlight = BuildConfig.DEBUG;
+  });
+  ```
+
+  You also need to allow cleartext traffic from your emulator to the Sidecar on your host machine by adding the following to `src/debug/res/xml/network.xml`:
+  ```xml {6}
+  <?xml version="1.0" encoding="utf-8"?>
+  <network-security-config>
+      <domain-config cleartextTrafficPermitted="true">
+          <!-- Allow cleartext traffic from the emulator to the host machine -->
+          <!-- See https://developer.android.com/studio/run/emulator-networking for more details -->
+          <domain includeSubdomains="true">10.0.2.2</domain>
+      </domain-config>
+  </network-security-config>
+  ```
+  </TabItem>
+  <TabItem label="iOS">
+  :::caution
+  Requires `sentry-cocoa` version `8.21.0` or higher.
+  :::
+  ```swift {3-6}
+  SentrySDK.start { options in
+      options.dsn = "___DSN___"
+#if DEBUG
+      // You should only enable this in your development environment
+      options.enableSpotlight = true
+#endif
+  }
+  ```
+  </TabItem>
+  <TabItem label="React Native">
+  :::caution
+  Requires `sentry-react-native` version `5.18.0` or higher.
+  :::
+  ```typescript {3}
+  Sentry.init({
+      dsn: '___DSN___',
+      enableSpotlight: __DEV__,
+  });
+  ```
+  </TabItem>
+  <TabItem label="Flutter">
+  :::caution
+  Requires `sentry-dart` version `7.15.0` or higher.
+  :::
+  ```dart {4}
+  await SentryFlutter.init((options) {
+      options.dsn = '___DSN___';
+      // You should only enable this in your development environment
+      options.spotlight = Spotlight(enabled: kDebugMode);
+  });
+  ```
+  </TabItem>
+</Tabs>

--- a/packages/website/src/components/sentryCodeBlockWeb.mdx
+++ b/packages/website/src/components/sentryCodeBlockWeb.mdx
@@ -1,5 +1,5 @@
 ---
-title: Sentry Setup Codeblock
+title: Sentry Setup Codeblock Web Platforms
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -76,72 +76,6 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
       // You should only load this in your development environment
       o.EnableSpotlight = true;
 #endif
-  });
-  ```
-  </TabItem>
-</Tabs>
-
-### Mobile platforms
-
-<Tabs>
-  <TabItem label="Android">
-  :::caution
-  Requires `sentry-java` version `7.4.0` or higher.
-  :::
-  ```kotlin {4}
-  SentryAndroid.init(this, options -> {
-      options.setDsn("___DSN___");
-      // You should only enable this in your development environment
-      options.isEnableSpotlight = BuildConfig.DEBUG;
-  });
-  ```
-
-  You also need to allow cleartext traffic from your emulator to the Sidecar on your host machine by adding the following to `src/debug/res/xml/network.xml`:
-  ```xml {6}
-  <?xml version="1.0" encoding="utf-8"?>
-  <network-security-config>
-      <domain-config cleartextTrafficPermitted="true">
-          <!-- Allow cleartext traffic from the emulator to the host machine -->
-          <!-- See https://developer.android.com/studio/run/emulator-networking for more details -->
-          <domain includeSubdomains="true">10.0.2.2</domain>
-      </domain-config>
-  </network-security-config>
-  ```
-  </TabItem>
-  <TabItem label="iOS">
-  :::caution
-  Requires `sentry-cocoa` version `8.21.0` or higher.
-  :::
-  ```swift {3-6}
-  SentrySDK.start { options in
-      options.dsn = "___DSN___"
-#if DEBUG
-      // You should only enable this in your development environment
-      options.enableSpotlight = true
-#endif
-  }
-  ```
-  </TabItem>
-  <TabItem label="React Native">
-  :::caution
-  Requires `sentry-react-native` version `5.18.0` or higher.
-  :::
-  ```typescript {3}
-  Sentry.init({
-      dsn: '___DSN___',
-      enableSpotlight: __DEV__,
-  });
-  ```
-  </TabItem>
-  <TabItem label="Flutter">
-  :::caution
-  Requires `sentry-dart` version `7.15.0` or higher.
-  :::
-  ```dart {4}
-  await SentryFlutter.init((options) {
-      options.dsn = '___DSN___';
-      // You should only enable this in your development environment
-      options.spotlight = Spotlight(enabled: kDebugMode);
   });
   ```
   </TabItem>

--- a/packages/website/src/content/docs/integrations/sentry.mdx
+++ b/packages/website/src/content/docs/integrations/sentry.mdx
@@ -7,6 +7,10 @@ Spotlight is built that you don't need Sentry to run it. It can contain any kind
 
 If you want your Sentry SDKs to talk to the Sidecar, enable the `spotlight` setting. You don't need a `dsn` for Spotlight to work.
 
-import { Content as SentryCodeBlock } from '../../../components/sentryCodeBlock.mdx';
+import { Content as SentryCodeBlockWeb } from '../../../components/sentryCodeBlockWeb.mdx';
 
-<SentryCodeBlock />
+<SentryCodeBlockWeb />
+
+import { Content as SentryCodeBlockMobile } from '../../../components/sentryCodeBlockMobile.mdx';
+
+<SentryCodeBlockMobile />

--- a/packages/website/src/content/docs/setup/astro.mdx
+++ b/packages/website/src/content/docs/setup/astro.mdx
@@ -63,6 +63,6 @@ See [Sentry's documentation](https://docs.sentry.io/platforms/javascript/guides/
 
 If your Astro application is interacting with other services, such as a Python API, you can also configure those SDKs to work with Spotlight. You don't need to be using the Sentry service to take advantage of Sentry's SDKs to power Spotlight.
 
-import { Content as SentryCodeBlock } from '../../../components/sentryCodeBlock.mdx';
+import { Content as SentryCodeBlockWeb } from '../../../components/sentryCodeBlockWeb.mdx';
 
-<SentryCodeBlock />
+<SentryCodeBlockWeb />

--- a/packages/website/src/content/docs/setup/other.mdx
+++ b/packages/website/src/content/docs/setup/other.mdx
@@ -100,7 +100,7 @@ Sentry.init({
 
 :::
 
-<LinkCard title="Setup Spotlight with Sentry" description="Instructions for Node, Python, PHP & Ruby" href="/setup/other/#tab-panel-19" />
+<LinkCard title="Setup Spotlight with Sentry" description="Instructions for Web and Mobile SDKs" href="#leverage-sentry-sdks" />
 
 ---
 

--- a/packages/website/src/content/docs/setup/other.mdx
+++ b/packages/website/src/content/docs/setup/other.mdx
@@ -120,6 +120,10 @@ Spotlight's [architecture](/architecture/) requires a sidecar to be running alon
 
 To get the most value out of Spotlight, configure Sentry's SDKs. You don't need to be using the Sentry service to take advantage of Sentry's SDKs to power Spotlight.
 
-import { Content as SentryCodeBlock } from '../../../components/sentryCodeBlock.mdx';
+import { Content as SentryCodeBlockWeb } from '../../../components/sentryCodeBlockWeb.mdx';
 
-<SentryCodeBlock />
+<SentryCodeBlockWeb />
+
+import { Content as SentryCodeBlockMobile } from '../../../components/sentryCodeBlockMobile.mdx';
+
+<SentryCodeBlockMobile />


### PR DESCRIPTION
- Fixes the link to "Setup Spotlight with Sentry"
- Adds new "Mobile platforms" section with config snippets for Mobile SDKs
- Current snippets are under "Web platforms" section

Putting all snippets in a single tabset was too much, but maybe there's a different/preferred way to solve this.

fixes https://github.com/getsentry/team-mobile/issues/176

Before opening this PR:

- [ ] ~~I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`~~
- [x] I referenced issues that this PR addresses

## Before

![Screenshot 2024-02-27 at 18 19 49](https://github.com/getsentry/spotlight/assets/2005158/7292e79c-5077-45f5-bf75-6567ca6d47e4)

## After

![Screenshot 2024-02-27 at 18 36 02](https://github.com/getsentry/spotlight/assets/2005158/e4f4c1f2-01aa-4cd9-9b26-45e4dc58294b)