### PR TITLE
fix: Show tags in root spans

### DIFF
--- a/.changeset/great-rings-battle.md
+++ b/.changeset/great-rings-battle.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+- To add tags from event instead of event context for root spans

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -135,6 +135,7 @@ class SentryDataCache {
         trace.transactions.forEach(txn => {
           allSpans.push({
             ...txn.contexts.trace,
+            tags: txn?.tags,
             start_timestamp: txn.start_timestamp,
             timestamp: txn.timestamp,
             description: traceCtx.description || txn.transaction,


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

issue raised by @lforst on discord - https://discord.com/channels/621778831602221064/1176977569678114847/1222548012937511003

Custom tags added to Sentry are not visible on root spans. 

Reason: While constructing root span for a trace, we used `event.context.trace` but it looks like tags are not up to date here. 
Fix: So for the patch, I've added tags from the event directly, which is up to date. for root custom spans