### PR TITLE
fix(overlay): To display metrics event as well in event envelopes

### DIFF
--- a/.changeset/tough-melons-hammer.md
+++ b/.changeset/tough-melons-hammer.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+- To display metrics event as well in event envelopes

--- a/packages/overlay/_fixtures/envelope_php_metrics.txt
+++ b/packages/overlay/_fixtures/envelope_php_metrics.txt
@@ -1,0 +1,3 @@
+{"event_id":"a1a5606d421f4f23aa316d7d67f937ba","sent_at":"2024-04-04T14:12:00Z","dsn":"https:\/\/key@o1.ingest.sentry.io\/project","sdk":{"name":"sentry.php.laravel","version":"4.4.0"},"trace":{"trace_id":"3f89a4ad500c4ec385710a7edfae7fd7","sample_rate":"1","transaction":"\/","public_key":"key","release":"1.0.0","environment":"local","sampled":"true"}}
+{"type":"statsd","length":70}
+counter:1|c|#environment:local,release:1.0.0,transaction:/|T1712239920

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -122,13 +122,16 @@ export function processEnvelope(rawEvent: RawEventContext) {
       continue;
     }
     const header = JSON.parse(rawEntries[i]);
-    if (header.type && header.type == 'statsd') {
-      // skip metric events
-      continue;
+    let payload;
+    try {
+      payload = JSON.parse(rawEntries[i + 1]);
+    } catch (e) {
+      // payload will not be json always, like in metrics events.
+      log(e);
+      payload = rawEntries[i + 1];
     }
-    const payload = JSON.parse(rawEntries[i + 1]);
     // data sanitization
-    if (header.type) {
+    if (header.type && typeof payload === 'object') {
       payload.type = header.type;
     }
     items.push([header, payload]);


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses


Earlier, we were skipping the events with the type as "statsd" (metric events). 
Because the type of items received in an envelope was not JSON. 

Now, with this fix, we will assign the string directly instead of parsing if the type is not JSON in the event envelope