### PR TITLE
Added a check for spotlight v1.x.x to not load sentry sdk >= v8

### DIFF
--- a/.changeset/cold-kings-rush.md
+++ b/.changeset/cold-kings-rush.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/spotlight': patch
+'@spotlightjs/overlay': patch
+---
+
+added a check for spotlight v1.x.x to not load sentry sdk >= v8

--- a/.changeset/ninety-days-tie.md
+++ b/.changeset/ninety-days-tie.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+updated the logic to retrieve the version of browser sentry sdk.

--- a/packages/overlay/src/components/Overview.tsx
+++ b/packages/overlay/src/components/Overview.tsx
@@ -51,7 +51,11 @@ export default function Overview({
       <Tabs tabs={tabs} setOpen={setOpen} />
       <div className="flex-1 overflow-auto overflow-x-hidden">
         <Routes>
-          <Route path="/not-found" element={<p>Not Found - How'd you manage to get here?</p>} key={'not-found'}></Route>
+          <Route
+            path="/not-found"
+            element={<div className="text-primary-300 p-6">Not Found - How'd you manage to get here?</div>}
+            key={'not-found'}
+          ></Route>
           {tabs.map(tab => {
             const TabContent = tab.content && tab.content;
 

--- a/packages/overlay/src/integrations/sentry/constants.ts
+++ b/packages/overlay/src/integrations/sentry/constants.ts
@@ -190,3 +190,5 @@ export const PERFORMANCE_SCORE_PROFILES = {
     // }
   ],
 };
+
+export const SDK_VERSION_SUPPORT_REGEX = /^[0-7]\.\d+\.\d+$/;

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -125,7 +125,7 @@ export default function sentryIntegration(options?: SentryIntegrationOptions) {
   if (checkBrowserSDKVersion()) {
     return _sentryIntegration(options);
   } else {
-    warn(`This version of Spotlight supports Sentry browser SDK version less than 8.x.x. Check out Spotlight v2.x.x`);
+    warn(`This version of Spotlight only supports Sentry browser SDK versions below 8.x.x. Check out Spotlight v2.x.x`);
     return _fallbackSentryIntegration();
   }
 }

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -1,14 +1,17 @@
 import type { Envelope } from '@sentry/types';
 import { getSpotlightEventTarget } from '../../lib/eventTarget';
-import { log } from '../../lib/logger';
+import { log, warn } from '../../lib/logger';
 import type { Integration, RawEventContext } from '../integration';
 import sentryDataCache from './data/sentryDataCache';
 import { Spotlight } from './sentry-integration';
 import DeveloperInfo from './tabs/DeveloperInfo';
 import ErrorsTab from './tabs/ErrorsTab';
+import InfoTab from './tabs/InfoTab';
 import PerformanceTab from './tabs/PerformanceTab';
 import SdksTab from './tabs/SdksTab';
 import TracesTab from './tabs/TracesTab';
+import { WindowWithSentry } from './types';
+import { checkBrowserSDKVersion } from './utils/sdkValidation';
 
 const HEADER = 'application/x-sentry-envelope';
 
@@ -18,97 +21,107 @@ type SentryIntegrationOptions = {
 };
 
 export default function sentryIntegration(options?: SentryIntegrationOptions) {
-  return {
-    name: 'sentry',
-    forwardedContentType: [HEADER],
+  if (checkBrowserSDKVersion()) {
+    return {
+      name: 'sentry',
+      forwardedContentType: [HEADER],
 
-    setup: ({ open }) => {
-      addSpotlightIntegrationToSentry(options);
+      setup: ({ open }) => {
+        addSpotlightIntegrationToSentry(options);
 
-      const spotlightEventTarget = getSpotlightEventTarget();
+        const spotlightEventTarget = getSpotlightEventTarget();
 
-      const onRenderError = (e: CustomEvent) => {
-        log('Sentry Event', e.detail.event_id);
-        if (e.detail.event) sentryDataCache.pushEvent(e.detail.event);
-        // TODO: handle async
-        open(`/errors/${e.detail.eventId}`);
-      };
+        const onRenderError = (e: CustomEvent) => {
+          log('Sentry Event', e.detail.event_id);
+          if (e.detail.event) sentryDataCache.pushEvent(e.detail.event);
+          // TODO: handle async
+          open(`/errors/${e.detail.eventId}`);
+        };
 
-      spotlightEventTarget.addEventListener('sentry:showError', onRenderError as EventListener);
+        spotlightEventTarget.addEventListener('sentry:showError', onRenderError as EventListener);
 
-      return () => {
-        spotlightEventTarget.removeEventListener('sentry:showError', onRenderError as EventListener);
-      };
-    },
+        return () => {
+          spotlightEventTarget.removeEventListener('sentry:showError', onRenderError as EventListener);
+        };
+      },
 
-    processEvent: (event: RawEventContext) => processEnvelope(event),
+      processEvent: (event: RawEventContext) => processEnvelope(event),
 
-    tabs: () => {
-      const errorsCount = sentryDataCache
-        .getEvents()
-        .filter(
-          e =>
-            e.type != 'transaction' &&
-            (e.contexts?.trace?.trace_id ? sentryDataCache.isTraceLocal(e.contexts?.trace?.trace_id) : null) !== false,
-        ).length;
+      tabs: () => {
+        const errorsCount = sentryDataCache
+          .getEvents()
+          .filter(
+            e =>
+              e.type != 'transaction' &&
+              (e.contexts?.trace?.trace_id ? sentryDataCache.isTraceLocal(e.contexts?.trace?.trace_id) : null) !==
+                false,
+          ).length;
 
-      const localTraces = sentryDataCache.getTraces().filter(t => sentryDataCache.isTraceLocal(t.trace_id) !== false);
+        const localTraces = sentryDataCache.getTraces().filter(t => sentryDataCache.isTraceLocal(t.trace_id) !== false);
 
-      return [
-        {
-          id: 'errors',
-          title: 'Errors',
-          notificationCount: {
-            count: errorsCount,
-            severe: errorsCount > 0,
+        return [
+          {
+            id: 'errors',
+            title: 'Errors',
+            notificationCount: {
+              count: errorsCount,
+              severe: errorsCount > 0,
+            },
+            content: ErrorsTab,
           },
-          content: ErrorsTab,
-        },
-        {
-          id: 'traces',
-          title: 'Traces',
-          notificationCount: {
-            count: localTraces.length,
+          {
+            id: 'traces',
+            title: 'Traces',
+            notificationCount: {
+              count: localTraces.length,
+            },
+            content: TracesTab,
           },
-          content: TracesTab,
-        },
-        {
-          id: 'performance',
-          title: 'Performance',
-          content: PerformanceTab,
-        },
-        {
-          id: 'sdks',
-          title: 'SDKs',
-          content: SdksTab,
-        },
-        {
-          id: 'devInfo',
-          title: 'Developer Info',
-          content: DeveloperInfo,
-        },
-      ];
-    },
+          {
+            id: 'performance',
+            title: 'Performance',
+            content: PerformanceTab,
+          },
+          {
+            id: 'sdks',
+            title: 'SDKs',
+            content: SdksTab,
+          },
+          {
+            id: 'devInfo',
+            title: 'Developer Info',
+            content: DeveloperInfo,
+          },
+        ];
+      },
 
-    reset: () => {
-      sentryDataCache.resetData();
-    },
-  } satisfies Integration<Envelope>;
+      reset: () => {
+        sentryDataCache.resetData();
+      },
+    } satisfies Integration<Envelope>;
+  } else {
+    warn(`This version of Spotlight supports Sentry browser SDK version less than 8.x.x. Check out Spotlight v2.x.x`);
+    return {
+      name: 'sentry',
+      forwardedContentType: [],
+      setup: () => {},
+      processEvent: () => undefined,
+      tabs: () => {
+        return [
+          {
+            id: 'info',
+            title: 'Info',
+            content: () =>
+              InfoTab({
+                info: 'This version of Spotlight supports Sentry browser SDK version less than 8.x.x. Check out Spotlight v2.x.x',
+              }),
+          },
+        ];
+      },
+      reset: () => {},
+    } satisfies Integration<Envelope>;
+  }
 }
-
-type WindowWithSentry = Window & {
-  __SENTRY__?: {
-    hub: {
-      getClient: () =>
-        | {
-            setupIntegrations: (force: boolean) => void;
-            addIntegration(integration: Integration): void;
-            on: (event: string, callback: (envelope: Envelope) => void) => void;
-          }
-        | undefined;
-    };
-  };
-};
 
 export function processEnvelope(rawEvent: RawEventContext) {
   const { data } = rawEvent;

--- a/packages/overlay/src/integrations/sentry/tabs/InfoTab.tsx
+++ b/packages/overlay/src/integrations/sentry/tabs/InfoTab.tsx
@@ -1,0 +1,3 @@
+export default function InfoTab({ info }: { info?: string }) {
+  return <div className="text-primary-300 p-6">{info}</div>;
+}

--- a/packages/overlay/src/integrations/sentry/types.ts
+++ b/packages/overlay/src/integrations/sentry/types.ts
@@ -1,4 +1,5 @@
-import { Measurements } from '@sentry/types';
+import { Envelope, Measurements } from '@sentry/types';
+import { Integration } from '../integration';
 
 export type FrameVars = {
   [key: string]: string;
@@ -211,4 +212,25 @@ export type MetricWeightsProps = {
   cls: number;
   fid: number;
   ttfb: number;
+};
+
+export type WindowWithSentry = Window & {
+  __SENTRY__?: {
+    hub: {
+      getClient: () =>
+        | {
+            setupIntegrations: (force: boolean) => void;
+            addIntegration(integration: Integration): void;
+            on: (event: string, callback: (envelope: Envelope) => void) => void;
+            getOptions: () => {
+              _metadata: {
+                sdk: {
+                  version: string;
+                };
+              };
+            };
+          }
+        | undefined;
+    };
+  };
 };

--- a/packages/overlay/src/integrations/sentry/utils/sdkValidation.ts
+++ b/packages/overlay/src/integrations/sentry/utils/sdkValidation.ts
@@ -1,11 +1,15 @@
 import { SDK_VERSION_SUPPORT_REGEX } from '../constants';
-import { WindowWithSentry } from '../types';
+import { LegacyCarrier, VersionedCarrier, WindowWithSentry } from '../types';
 
 export function checkBrowserSDKVersion() {
-  const spotlightV1SupportedSentryRegex = new RegExp(SDK_VERSION_SUPPORT_REGEX);
-  const sentrySDKVersion = (window as WindowWithSentry).__SENTRY__?.hub?.getClient()?.getOptions()?._metadata?.sdk
-    ?.version;
+  const sentrySDKVersionPreV8 = ((window as WindowWithSentry).__SENTRY__ as LegacyCarrier)?.hub
+    ?.getClient()
+    ?.getOptions()?._metadata?.sdk?.version;
+
+  const sentrySDKVersionPostV8 = ((window as WindowWithSentry).__SENTRY__ as VersionedCarrier)?.version;
 
   // if browser SDK verion not found, return true to load the events from server side.
-  return sentrySDKVersion ? spotlightV1SupportedSentryRegex.test(sentrySDKVersion) : true;
+  return sentrySDKVersionPreV8 || sentrySDKVersionPostV8
+    ? new RegExp(SDK_VERSION_SUPPORT_REGEX).test(sentrySDKVersionPreV8 || sentrySDKVersionPostV8)
+    : true;
 }

--- a/packages/overlay/src/integrations/sentry/utils/sdkValidation.ts
+++ b/packages/overlay/src/integrations/sentry/utils/sdkValidation.ts
@@ -1,0 +1,11 @@
+import { SDK_VERSION_SUPPORT_REGEX } from '../constants';
+import { WindowWithSentry } from '../types';
+
+export function checkBrowserSDKVersion() {
+  const spotlightV1SupportedSentryRegex = new RegExp(SDK_VERSION_SUPPORT_REGEX);
+  const sentrySDKVersion = (window as WindowWithSentry).__SENTRY__?.hub?.getClient()?.getOptions()?._metadata?.sdk
+    ?.version;
+
+  // if browser SDK verion not found, return true to load the events from server side.
+  return sentrySDKVersion ? spotlightV1SupportedSentryRegex.test(sentrySDKVersion) : true;
+}

--- a/packages/overlay/src/lib/logger.ts
+++ b/packages/overlay/src/lib/logger.ts
@@ -13,3 +13,21 @@ export function log(...args: unknown[]) {
     console.log('🔎 [Spotlight]', ...args);
   }
 }
+
+export function warn(...args: unknown[]) {
+  if (loggerActive) {
+    console.warn('🔎 [Spotlight]', ...args);
+  }
+}
+
+export function info(...args: unknown[]) {
+  if (loggerActive) {
+    console.info('🔎 [Spotlight]', ...args);
+  }
+}
+
+export function error(...args: unknown[]) {
+  if (loggerActive) {
+    console.error('🔎 [Spotlight]', ...args);
+  }
+}

--- a/packages/website/src/components/InstallCommand.mdx
+++ b/packages/website/src/components/InstallCommand.mdx
@@ -7,17 +7,17 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs>
   <TabItem label="npm">
   ```sh 
-  npm add @spotlightjs/spotlight
+  npm i @spotlightjs/spotlight --save-dev
   ```
   </TabItem>
   <TabItem label="pnpm">
   ```sh 
-  pnpm add @spotlightjs/spotlight
+  pnpm add -D @spotlightjs/spotlight
   ```
   </TabItem>
   <TabItem label="yarn">
   ```sh 
-  yarn add @spotlightjs/spotlight
+  yarn add -D @spotlightjs/spotlight
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses

Added a check for sentry integration in Spotlight, for v1.x.x to load only if - 
- no browser sdk found.
- browser sdk with version <= 7.x.x

![image](https://github.com/getsentry/spotlight/assets/43654389/e28ae62f-6704-40f2-bd03-00451af67454)

