### PR TITLE
Fixed the collapsing of spans in trace detail

### DIFF
--- a/.changeset/honest-ducks-hang.md
+++ b/.changeset/honest-ducks-hang.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fixed collapsing of spans in trace detail

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceDetails.tsx
@@ -31,7 +31,6 @@ export default function TraceDetails() {
 
   const startTimestamp = trace.start_timestamp;
   const totalDuration = trace.timestamp - startTimestamp;
-  const isCollapsible = trace.transactions.length > 1 || trace.spans.length >= 50;
 
   return (
     <>
@@ -69,7 +68,7 @@ export default function TraceDetails() {
           tree={trace.spanTree}
           startTimestamp={startTimestamp}
           totalDuration={totalDuration}
-          collapsible={isCollapsible}
+          totalTransactions={(trace.transactions || []).length}
           spanNodeWidth={spanNodeWidth}
           setSpanNodeWidth={setSpanNodeWidth}
         />
@@ -80,7 +79,7 @@ export default function TraceDetails() {
           startTimestamp={startTimestamp}
           totalDuration={totalDuration}
           span={span}
-          collapsible={isCollapsible}
+          totalTransactions={(trace.transactions || []).length}
         />
       ) : null}
     </>

--- a/packages/overlay/src/integrations/sentry/components/traces/spans/SpanDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/spans/SpanDetails.tsx
@@ -34,13 +34,13 @@ export default function SpanDetails({
   span,
   startTimestamp,
   totalDuration,
-  collapsible = false,
+  totalTransactions,
 }: {
   traceContext: TraceContext;
   span: Span;
+  totalTransactions?: number;
   startTimestamp: number;
   totalDuration: number;
-  collapsible?: boolean;
 }) {
   const [spanNodeWidth, setSpanNodeWidth] = useState<number>(50);
 
@@ -213,7 +213,7 @@ export default function SpanDetails({
               tree={[span]}
               startTimestamp={startTimestamp}
               totalDuration={totalDuration}
-              collapsible={collapsible}
+              totalTransactions={totalTransactions}
               spanNodeWidth={spanNodeWidth}
               setSpanNodeWidth={setSpanNodeWidth}
             />

--- a/packages/overlay/src/integrations/sentry/components/traces/spans/SpanItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/spans/SpanItem.tsx
@@ -14,7 +14,7 @@ const SpanItem = ({
   totalDuration,
   depth = 1,
   traceContext,
-  collapsible = false,
+  totalTransactions = 0,
   spanNodeWidth,
   setSpanNodeWidth = () => {},
 }: {
@@ -23,13 +23,15 @@ const SpanItem = ({
   totalDuration: number;
   depth?: number;
   traceContext: TraceContext;
-  collapsible?: boolean;
+  totalTransactions?: number;
   spanNodeWidth: number;
   setSpanNodeWidth?: (val: number) => void;
 }) => {
   const { spanId } = useParams();
   const containerRef = useRef<HTMLLIElement>(null);
-  const [renderChildren, setRenderChildren] = useState(!collapsible || depth <= 5);
+  const [isItemCollapsed, setIsItemCollapsed] = useState(
+    (span.transaction && totalTransactions > 1 && depth !== 1) || depth >= 15,
+  );
   const [isResizing, setIsResizing] = useState(false);
 
   const spanDuration = getDuration(span.start_timestamp, span.timestamp);
@@ -64,19 +66,19 @@ const SpanItem = ({
             width: `${spanNodeWidth}%`,
           }}
         >
-          {collapsible && (span.children || []).length > 0 && (
+          {(span.children || []).length > 0 && (
             <div
               className="bg-primary-600 z-10 mr-1 flex items-center gap-1 rounded-lg px-1 text-xs font-bold text-white"
               onClick={e => {
                 e.preventDefault();
-                setRenderChildren(prev => !prev);
+                setIsItemCollapsed(prev => !prev);
               }}
             >
               {(span.children || []).length}
               <ChevronIcon
                 width={12}
                 height={12}
-                className={classNames('transition', renderChildren ? 'rotate-180' : 'rotate-0')}
+                className={classNames('transition', isItemCollapsed ? 'rotate-0' : 'rotate-180')}
               />
             </div>
           )}
@@ -112,14 +114,14 @@ const SpanItem = ({
         </div>
       </Link>
 
-      {renderChildren && (
+      {!isItemCollapsed && (
         <SpanTree
           traceContext={traceContext}
           tree={span.children || []}
           startTimestamp={startTimestamp}
           totalDuration={totalDuration}
           depth={depth + 1}
-          collapsible={collapsible}
+          totalTransactions={totalTransactions}
           spanNodeWidth={spanNodeWidth}
           setSpanNodeWidth={setSpanNodeWidth}
         />

--- a/packages/overlay/src/integrations/sentry/components/traces/spans/SpanTree.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/spans/SpanTree.tsx
@@ -7,7 +7,7 @@ export default function SpanTree({
   startTimestamp,
   totalDuration,
   depth = 1,
-  collapsible = false,
+  totalTransactions,
   spanNodeWidth,
   setSpanNodeWidth,
 }: {
@@ -16,7 +16,7 @@ export default function SpanTree({
   startTimestamp: number;
   totalDuration: number;
   depth?: number;
-  collapsible?: boolean;
+  totalTransactions?: number;
   spanNodeWidth: number;
   setSpanNodeWidth?: (val: number) => void;
 }) {
@@ -31,9 +31,9 @@ export default function SpanTree({
             traceContext={traceContext}
             depth={depth}
             span={span}
+            totalTransactions={totalTransactions}
             startTimestamp={startTimestamp}
             totalDuration={totalDuration}
-            collapsible={collapsible}
             spanNodeWidth={spanNodeWidth}
             setSpanNodeWidth={setSpanNodeWidth}
           />


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses

fixes: #278 

- Removed the condition to remove collapsing the spans when there is only 1 transaction and <50 spans. Now the spans will always we collapsible.
- Modified condition to auto collapse spans.
  - Span will be auto collapsed after depth of 15
  - Transaction span will be collapsed when total Transactions are  > 1 and when depth is also not 1 (not collapse the root transaction)
