### PR TITLE
doc(website): Add migration guide for updating to 2.x

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -125,6 +125,10 @@ export default defineConfig({
               label: 'For Other Frameworks',
               link: '/setup/other/',
             },
+            {
+              label: 'Migration Guide',
+              link: '/setup/migration/',
+            },
           ],
         },
         {

--- a/packages/website/src/content/docs/setup/migration.mdx
+++ b/packages/website/src/content/docs/setup/migration.mdx
@@ -5,7 +5,7 @@ description: A guide how to update and migrate to the latest version of Spotligh
 
 On this page, you'll learn how to update your Spotlight setup to the latest version.
 
-## Migrating from 1.x to 2.x
+## Updating from 1.x to 2.x
 
 Version 2.x of Spotlight was introduced to establish compatibility with version 8 of [Sentry's JavaScript SDKs](https://docs.sentry.io/platforms/javascript/).
 Some of the breaking v8 SDK changes required changes in how Spotlight interacts with the Sentry SDK. 
@@ -28,5 +28,7 @@ If you're using Spotlight without a Sentry JavaScript SDK, for example for mobil
 ### Other Breaking Changes
 
 None! With the exception of ensuring you have the correct the Sentry JavaScript SDK version, there are no other breaking changes in Spotlight 2.x. 
+
+If you encounter problems while updating to 2.x, please let us know by [opening an issue](https://github.com/getsentry/spotlight/issues/new/choose)!
 
 \* The `@spotlightjs/electron` app was only updated to version 2 because it depends on the `@spotlightjs/overlay` package. There are no breaking changes when using the Electron app!

--- a/packages/website/src/content/docs/setup/migration.mdx
+++ b/packages/website/src/content/docs/setup/migration.mdx
@@ -18,7 +18,7 @@ Affected packages:
 
 ### New minimum Sentry JavaScript SDK versions
 
-Version 2.x of Spotlight is only compatible with versions `>=7.99.0` or `8.x` one of Sentry's JavaScript SDKs like (`@sentry/browser`, `@sentry/react` or `@sentry/nextjs`). 
+Version 2.x of Spotlight is only compatible with versions `>=7.99.0` or `8.x` of Sentry's JavaScript SDKs like (`@sentry/browser`, `@sentry/react` or `@sentry/nextjs`). 
 Older SDK versions are no longer supported in Spotlight 2.x. 
 
 ### Changes for non-JavaScript SDK Users

--- a/packages/website/src/content/docs/setup/migration.mdx
+++ b/packages/website/src/content/docs/setup/migration.mdx
@@ -23,7 +23,7 @@ Older SDK versions are no longer supported in Spotlight 2.x.
 
 ### Changes for non-JavaScript SDK Users
 
-If you're using Spotlight without a Sentry JavaScript SDK, for example for mobile (iOS/Android/ReactNative etc.) or server-side (Python/Ruby/etc.) applications, you update directly to version 2.x without any required changes.
+If you're using Spotlight without a Sentry JavaScript SDK, for example for mobile (iOS/Android/ReactNative etc.) or server-side (Python/Ruby/etc.) applications, you can update directly to version 2.x without making any changes.
 
 ### Other Breaking Changes
 

--- a/packages/website/src/content/docs/setup/migration.mdx
+++ b/packages/website/src/content/docs/setup/migration.mdx
@@ -5,10 +5,10 @@ description: A guide how to update and migrate to the latest version of Spotligh
 
 On this page, you'll learn how to update your Spotlight setup to the latest version.
 
-# Migrating from 1.x to 2.x
+## Migrating from 1.x to 2.x
 
 Version 2.x of Spotlight was introduced to establish compatibility with version 8 of [Sentry's JavaScript SDKs](https://docs.sentry.io/platforms/javascript/).
-Some of the breaking v8 SDK changes required changes in how Spotlight interacts with the SDK. 
+Some of the breaking v8 SDK changes required changes in how Spotlight interacts with the Sentry SDK. 
 
 Affected packages:
 - Spotlight Main Package (`@spotlightjs/spotlight`) 
@@ -16,16 +16,16 @@ Affected packages:
 - Spotlight Overlay (`@spotlightjs/overlay`)
 - Spotlight Electron App* (`@spotlightjs/electron`)
 
-## New minimum Sentry JavaScript SDK versions
+### New minimum Sentry JavaScript SDK versions
 
 Version 2.x of Spotlight is only compatible with versions `>=7.99.0` or `8.x` one of Sentry's JavaScript SDKs like (`@sentry/browser`, `@sentry/react` or `@sentry/nextjs`). 
 Older SDK versions are no longer supported in Spotlight 2.x. 
 
-## Changes for non-JavaScript SDK Users
+### Changes for non-JavaScript SDK Users
 
 If you're using Spotlight without a Sentry JavaScript SDK, for example for mobile (iOS/Android/ReactNative etc.) or server-side (Python/Ruby/etc.) applications, you update directly to version 2.x without any required changes.
 
-## Other Breaking Changes
+### Other Breaking Changes
 
 None! With the exception of ensuring you have the correct the Sentry JavaScript SDK version, there are no other breaking changes in Spotlight 2.x. 
 

--- a/packages/website/src/content/docs/setup/migration.mdx
+++ b/packages/website/src/content/docs/setup/migration.mdx
@@ -1,0 +1,32 @@
+---
+title: Spotlight Migration Guide
+description: A guide how to update and migrate to the latest version of Spotlight versions
+---
+
+On this page, you'll learn how to update your Spotlight setup from older versions to the latest version.
+
+# Migrating from 1.x to 2.x
+
+Version 2.x of Spotlight was introduced to establish compatibility with version 8 of [Sentry's JavaScript SDKs](https://docs.sentry.io/platforms/javascript/).
+Some of the breaking v8 SDK changes required changes in how Spotlight interacts with the SDK. 
+
+Affected packages:
+- Spotlight Main Package (`@spotlightjs/spotlight`) 
+- Spotlight for Astro (`@spotlightjs/astro`) 
+- Spotlight Overlay (`@spotlightjs/overlay`)
+- Spotlight Electron App* (`@spotlightjs/electron`)
+
+## New minimum Sentry JavaScript SDK versions
+
+Version 2.x of Spotlight is only compatible with versions `>=7.99.0` or `8.x` one of Sentry's JavaScript SDKs like (`@sentry/browser`, `@sentry/react` or `@sentry/nextjs`). 
+Older SDK versions are no longer supported in Spotlight 2.x. 
+
+## Changes for non-JavaScript SDK Users
+
+If you're using Spotlight without a Sentry JavaScript SDK, for example for mobile (iOS/Android/ReactNative etc.) or server-side (Python/Ruby/etc.) applications, you update directly to version 2.x without any required changes.
+
+## Other Breaking Changes
+
+None! With the exception of ensuring you have the correct the Sentry JavaScript SDK version, there are no other breaking changes in Spotlight 2.x. 
+
+\* The `@spotlightjs/electron` app was only updated to version 2 because it depends on the `@spotlightjs/overlay` package. There are no breaking changes when using the Electron app!

--- a/packages/website/src/content/docs/setup/migration.mdx
+++ b/packages/website/src/content/docs/setup/migration.mdx
@@ -3,7 +3,7 @@ title: Spotlight Migration Guide
 description: A guide how to update and migrate to the latest version of Spotlight versions
 ---
 
-On this page, you'll learn how to update your Spotlight setup from older versions to the latest version.
+On this page, you'll learn how to update your Spotlight setup to the latest version.
 
 # Migrating from 1.x to 2.x
 


### PR DESCRIPTION
Adds a migration guide for Spotlight 1.x -> 2.x

The good news: The only breaking change is the version compatibility range for the Sentry JS SDK. Tried to clarify this in the guide and explicitly mention that the update should be smooth sailing for mobile/backend/non JS SDK users.

[Page Preview](https://spotlightjs-git-lms-feat-website-migration-guide.sentry.dev/setup/migration/) 