### PR TITLE
ref: More robust client init code generation

### DIFF
--- a/packages/astro/src/snippets.ts
+++ b/packages/astro/src/snippets.ts
@@ -12,21 +12,18 @@ export type ClientInitOptions = {
 const buildClientImport = (importPath: string) => `import * as Spotlight from ${JSON.stringify(importPath)};`;
 
 const buildClientInit = (options: ClientInitOptions) => {
-  const integrationCalls = options.integrationNames
-    ? options.integrationNames.map(i => `Spotlight.${i}()`).join(', ')
-    : `Spotlight.sentry({sidecarUrl: ${options.sidecarUrl ? `'${options.sidecarUrl}'` : undefined}})`;
+  let initOptions = JSON.stringify({
+    showTriggerButton: options.showTriggerButton !== false,
+    injectImmediately: options.injectImmediately,
+    debug: options.debug,
+    sidecarUrl: options.sidecarUrl,
+  });
 
-  return `
-Spotlight.init({
-  integrations: [
-    ${integrationCalls}
-  ],
-  showTriggerButton: ${options.showTriggerButton === false ? 'false' : 'true'},
-  injectImmediately: ${options.injectImmediately === true ? 'true' : 'false'},
-  debug: ${options.debug === true ? 'true' : 'false'},
-  ${options.sidecarUrl ? `sidecarUrl: '${options.sidecarUrl}'` : ''}
-});
-`;
+  const integrationOptions = JSON.stringify({ sidecarUrl: options.sidecarUrl });
+  const integrations = (options.integrationNames || ['sentry']).map(i => `Spotlight.${i}(${integrationOptions})`);
+  initOptions = `{integrations: [${integrations.join(', ')}], ${initOptions.slice(1)}`;
+
+  return `Spotlight.init(${initOptions});`;
 };
 
 export const buildClientInitSnippet = (options: ClientInitOptions) => `
@@ -40,7 +37,7 @@ ${buildClientInit(options)}
  * Main difference to normal page injection: We only initialize spotlight
  * if an error happens and is transmitted via the websocket. This is to avoid
  * initializing this spotlight instance before the actual app's instance.
- * This should only be  the fallback instance if the app failed to intialize.
+ * This should only be the fallback instance if the app failed to initialize.
  *
  * Used variables from Vite's client code:
  * - `enableOverlay` to check if the overlay should be shown


### PR DESCRIPTION
The current client init code generation is a bit fragile. It also does not pass the sidecarUrl option to any other potential integrations. This PR fixes that issue and makes the code generation more robust and readable.
