### PR TITLE
fix: Always trim befor trying to JSON.parse

### DIFF
--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -105,7 +105,7 @@ export default function sentryIntegration(options?: SentryIntegrationOptions) {
 
 export function processEnvelope(rawEvent: RawEventContext) {
   const { data } = rawEvent;
-  const [rawHeader, ...rawEntries] = data.split(/\n/gm);
+  const [rawHeader, ...rawEntries] = data.trim().split(/\n/gm);
 
   const header = JSON.parse(rawHeader) as Envelope[0];
   const items: Envelope[1][] = [];


### PR DESCRIPTION
In #429, we started sending an empty payload at the start to trigger connect event on Firefox. Our data parser does not account for this and gets confused, causing an error. This patch fixes that.
