### PR TITLE
fix: Fix ups for the vite-plugin PR

### DIFF
--- a/demos/astro-playground/astro.config.mjs
+++ b/demos/astro-playground/astro.config.mjs
@@ -27,10 +27,7 @@ export default defineConfig({
     react({ include: ['**/react/*'] }),
     sentry({
       debug: true,
-      sourceMapsUploadOptions: {
-        enabled: false, // tmp deactivate until version after 7.83.0
-      },
     }),
-    spotlight(),
+    spotlight({ debug: true }),
   ],
 });

--- a/demos/astro-playground/package.json
+++ b/demos/astro-playground/package.json
@@ -17,7 +17,7 @@
     "@astrojs/node": "^6.0.4",
     "@astrojs/react": "^3.0.5",
     "@astrojs/svelte": "^4.0.4",
-    "@sentry/astro": "8.7.0",
+    "@sentry/astro": "^8.7.0",
     "@spotlightjs/astro": "workspace:*",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -32,8 +32,6 @@ const createPlugin = (options?: SpotlightInitOptions): AstroIntegration => {
         if (command === 'dev') {
           logger.info('[@spotlightjs/astro] Setting up Spotlight');
 
-          config.vite.plugins = [spotlight({ showTriggerButton: false }), ...(config.vite.plugins || [])];
-
           // Since Astro 4.0.0-beta.4, `devToolbar` is set and enabled by default.
           // briefly, `devOverlay` was also added to the config but is now deprecated.
           // Setting either of these to `true` or not setting any of them in the config file
@@ -48,7 +46,8 @@ const createPlugin = (options?: SpotlightInitOptions): AstroIntegration => {
 
           const showTriggerButton = !hasToolbarEnabled && !hasExperimentalDevOverlayEnabled;
 
-          injectScript('page', buildClientInit({ showTriggerButton, ...options }));
+          config.vite.plugins = [spotlight({ showTriggerButton, ...options }), ...(config.vite.plugins || [])];
+
           injectScript('page-ssr', buildServerSnippet(options));
 
           const importPath = path.dirname(url.fileURLToPath(import.meta.url));
@@ -70,4 +69,3 @@ const createPlugin = (options?: SpotlightInitOptions): AstroIntegration => {
 };
 
 export default createPlugin;
-export * from '@spotlightjs/spotlight';

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -17,21 +17,24 @@ type SentryIntegrationOptions = {
   sidecarUrl?: string;
   injectIntoSDK?: boolean;
   openLastError?: boolean;
+  retries?: number;
 };
 
-export default function sentryIntegration(options?: SentryIntegrationOptions) {
+export default function sentryIntegration(options: SentryIntegrationOptions = {}) {
   return {
     name: 'sentry',
     forwardedContentType: [HEADER],
 
     setup: ({ open }) => {
+      if (options.retries == null) {
+        options.retries = 3;
+      }
       addSpotlightIntegrationToSentry(options);
 
       if (options?.openLastError) {
-        const unsubscribe = sentryDataCache.subscribe('event', (e: SentryEvent) => {
+        sentryDataCache.subscribe('event', (e: SentryEvent) => {
           if (!(e as SentryErrorEvent).exception) return;
           setTimeout(() => open(`/errors/${e.event_id}`), 0);
-          unsubscribe();
         });
       }
 
@@ -145,7 +148,7 @@ export function processEnvelope(rawEvent: RawEventContext) {
 
     // data sanitization
     if (itemHeader.type && typeof itemPayload === 'object') {
-      // @ts-expect-error -- we should fix the types here
+      // @ts-expect-error -- Does not like assigning to `type` on random object
       itemPayload.type = itemHeader.type;
     }
     items.push([itemHeader, itemPayload] as EnvelopeItem);
@@ -197,8 +200,8 @@ type WindowWithSentry = Window & {
  *
  * @param options options of the Sentry integration for Spotlight
  */
-function addSpotlightIntegrationToSentry(options?: SentryIntegrationOptions) {
-  if (options?.injectIntoSDK === false) {
+function addSpotlightIntegrationToSentry(options: SentryIntegrationOptions) {
+  if (options.injectIntoSDK === false) {
     return;
   }
 
@@ -207,6 +210,13 @@ function addSpotlightIntegrationToSentry(options?: SentryIntegrationOptions) {
 
   if (!sentryClient) {
     log("Couldn't find a Sentry SDK client. Make sure you're using a Sentry SDK with version >=7.99.0 or 8.x");
+    if (options.retries) {
+      log(`Will retry ${options.retries} more time(s) at 100ms intervals...`);
+      options.retries--;
+      setTimeout(() => {
+        addSpotlightIntegrationToSentry(options);
+      }, 100);
+    }
     return;
   }
 

--- a/packages/overlay/test/integrations/sentry/data/sentryDataCache.test.ts
+++ b/packages/overlay/test/integrations/sentry/data/sentryDataCache.test.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 
 describe('SentryDataCache', () => {
   // We need to refactor this to make it actually testable
-  test('Process Envelope', async () => {
+  test('Process Envelope', () => {
     const envelope = fs.readFileSync('./_fixtures/envelope_javascript.txt', 'utf-8');
     const processedEnvelope = processEnvelope({ data: envelope, contentType: 'test' });
     expect(

--- a/packages/overlay/test/integrations/sentry/data/sentryDataCache.test.ts
+++ b/packages/overlay/test/integrations/sentry/data/sentryDataCache.test.ts
@@ -6,7 +6,7 @@ import fs from 'fs';
 
 describe('SentryDataCache', () => {
   // We need to refactor this to make it actually testable
-  test('Process Envelope', () => {
+  test('Process Envelope', async () => {
     const envelope = fs.readFileSync('./_fixtures/envelope_javascript.txt', 'utf-8');
     const processedEnvelope = processEnvelope({ data: envelope, contentType: 'test' });
     expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,8 +74,8 @@ importers:
         specifier: ^4.0.4
         version: 4.0.4(astro@3.5.5)(svelte@5.0.0-next.4)(typescript@5.2.2)(vite@4.5.3)
       '@sentry/astro':
-        specifier: 8.7.0
-        version: 8.7.0(astro@3.5.5)
+        specifier: ^8.7.0
+        version: 8.9.2(astro@3.5.5)
       '@spotlightjs/astro':
         specifier: workspace:*
         version: link:../../packages/astro
@@ -231,7 +231,7 @@ importers:
     dependencies:
       '@sentry/sveltekit':
         specifier: 8.7.0
-        version: 8.7.0(@opentelemetry/api@1.8.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1)(@sveltejs/kit@1.27.6)(svelte@4.2.7)
+        version: 8.7.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1)(@sveltejs/kit@1.27.6)(svelte@4.2.7)
     devDependencies:
       '@fontsource/fira-mono':
         specifier: ^4.5.10
@@ -3105,11 +3105,6 @@ packages:
     engines: {node: '>=8.0.0'}
     dev: false
 
-  /@opentelemetry/api@1.8.0:
-    resolution: {integrity: sha512-I/s6F7yKUDdtMsoBWXJe8Qz40Tui5vsuKCWJEWVL+5q9sSWRzzx6v2KeNsOBEwd94j0eWkpWCH4yB6rZg9Mf0w==}
-    engines: {node: '>=8.0.0'}
-    dev: false
-
   /@opentelemetry/api@1.9.0:
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
     engines: {node: '>=8.0.0'}
@@ -3200,16 +3195,6 @@ packages:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
     dependencies:
       '@opentelemetry/api': 1.7.0
-      '@opentelemetry/semantic-conventions': 1.25.1
-    dev: false
-
-  /@opentelemetry/core@1.25.1(@opentelemetry/api@1.8.0):
-    resolution: {integrity: sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-    dependencies:
-      '@opentelemetry/api': 1.8.0
       '@opentelemetry/semantic-conventions': 1.25.1
     dev: false
 
@@ -3870,23 +3855,6 @@ packages:
       - supports-color
     dev: false
 
-  /@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.8.0):
-    resolution: {integrity: sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.3.0
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/api-logs': 0.51.1
-      '@types/shimmer': 1.0.5
-      import-in-the-middle: 1.7.4
-      require-in-the-middle: 7.3.0
-      semver: 7.5.4
-      shimmer: 1.2.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@opentelemetry/instrumentation@0.51.1(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-JIrvhpgqY6437QIqToyozrUG1h5UhwHkaGK/WAX+fkrpyPtc+RO5FkRtUd9BH0MibabHHvqsnBGKfKVijbmp8w==}
     engines: {node: '>=14'}
@@ -3987,17 +3955,6 @@ packages:
       '@opentelemetry/semantic-conventions': 1.22.0
     dev: false
 
-  /@opentelemetry/resources@1.25.1(@opentelemetry/api@1.8.0):
-    resolution: {integrity: sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.25.1
-    dev: false
-
   /@opentelemetry/resources@1.25.1(@opentelemetry/api@1.9.0):
     resolution: {integrity: sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==}
     engines: {node: '>=14'}
@@ -4055,18 +4012,6 @@ packages:
       '@opentelemetry/core': 1.21.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/resources': 1.21.0(@opentelemetry/api@1.7.0)
       '@opentelemetry/semantic-conventions': 1.21.0
-    dev: false
-
-  /@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.8.0):
-    resolution: {integrity: sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      '@opentelemetry/api': '>=1.0.0 <1.10.0'
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/resources': 1.25.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.25.1
     dev: false
 
   /@opentelemetry/sdk-trace-base@1.25.1(@opentelemetry/api@1.9.0):
@@ -4623,17 +4568,17 @@ packages:
       - supports-color
     dev: false
 
-  /@sentry/astro@8.7.0(astro@3.5.5):
-    resolution: {integrity: sha512-wU1tIBhBPQa+KMCXeBzauXWO+7p1mTLe/sIepIuggQMd/zFxhroGNVO0ZZUXXUg/Zst4tIn6ZQ47DVG2ZuDB2Q==}
+  /@sentry/astro@8.9.2(astro@3.5.5):
+    resolution: {integrity: sha512-jYMJqvD3Yz9EAlGJD2etwsm7/Z6g4ueEXJfUYHqvSjhdRBeSmJuNLKJJBLpVJZiH+fpuBdP19UN/y7iYoAxR8g==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
       astro: '>=3.x || >=4.0.0-beta'
     dependencies:
-      '@sentry/browser': 8.7.0
-      '@sentry/core': 8.7.0
-      '@sentry/node': 8.7.0
-      '@sentry/types': 8.7.0
-      '@sentry/utils': 8.7.0
+      '@sentry/browser': 8.9.2
+      '@sentry/core': 8.9.2
+      '@sentry/node': 8.9.2
+      '@sentry/types': 8.9.2
+      '@sentry/utils': 8.9.2
       '@sentry/vite-plugin': 2.20.1
       astro: 3.5.5(typescript@5.2.2)
     transitivePeerDependencies:
@@ -5180,26 +5125,6 @@ packages:
       '@sentry/utils': 8.16.0
     dev: false
 
-  /@sentry/opentelemetry@8.7.0(@opentelemetry/api@1.8.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1):
-    resolution: {integrity: sha512-I9JEXnqXDBPr5MtgEYRvmcolmpugSgH1QV+SFnfOPc40Mu/npNsJq7oqbGzhlCe4H45XD6LJzFlc7BfoCzwAsQ==}
-    engines: {node: '>=14.18'}
-    peerDependencies:
-      '@opentelemetry/api': ^1.8.0
-      '@opentelemetry/core': ^1.24.1
-      '@opentelemetry/instrumentation': ^0.51.1
-      '@opentelemetry/sdk-trace-base': ^1.23.0
-      '@opentelemetry/semantic-conventions': ^1.23.0
-    dependencies:
-      '@opentelemetry/api': 1.8.0
-      '@opentelemetry/core': 1.25.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/instrumentation': 0.51.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/sdk-trace-base': 1.25.1(@opentelemetry/api@1.8.0)
-      '@opentelemetry/semantic-conventions': 1.25.1
-      '@sentry/core': 8.7.0
-      '@sentry/types': 8.7.0
-      '@sentry/utils': 8.7.0
-    dev: false
-
   /@sentry/opentelemetry@8.7.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1):
     resolution: {integrity: sha512-I9JEXnqXDBPr5MtgEYRvmcolmpugSgH1QV+SFnfOPc40Mu/npNsJq7oqbGzhlCe4H45XD6LJzFlc7BfoCzwAsQ==}
     engines: {node: '>=14.18'}
@@ -5320,7 +5245,7 @@ packages:
       - svelte
     dev: false
 
-  /@sentry/sveltekit@8.7.0(@opentelemetry/api@1.8.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1)(@sveltejs/kit@1.27.6)(svelte@4.2.7):
+  /@sentry/sveltekit@8.7.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1)(@sveltejs/kit@1.27.6)(svelte@4.2.7):
     resolution: {integrity: sha512-1fIonUwv5yICQFfaNAMrCYkwRF9c2kp8LLbTUaMXNFrDbJV1I8afXIWJFc8O0Q3/cW22QGdLhH67Mvb5SA81Wg==}
     engines: {node: '>=16'}
     peerDependencies:
@@ -5328,7 +5253,7 @@ packages:
     dependencies:
       '@sentry/core': 8.7.0
       '@sentry/node': 8.7.0
-      '@sentry/opentelemetry': 8.7.0(@opentelemetry/api@1.8.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1)
+      '@sentry/opentelemetry': 8.7.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.25.1)(@opentelemetry/instrumentation@0.51.1)(@opentelemetry/sdk-trace-base@1.25.1)(@opentelemetry/semantic-conventions@1.25.1)
       '@sentry/svelte': 8.7.0(svelte@4.2.7)
       '@sentry/types': 8.7.0
       '@sentry/utils': 8.7.0


### PR DESCRIPTION
Fixes up #434.

We sometimes load Spotlight befor a Sentry SDK is loaded which
then bails on running the integration with it, making it lose
most of its appeal. To fix this, this PR adds a retry mechanism
which tries detecting Sentry SDK up to 3 times.

This works on the first try if it's just an ordering problem. It
however would not work where a Sentry SDK is loaded on-demand as
we don't have an "on load event" for Sentry SDK.
