### PR TITLE
feat: Add ability to use Sidecar in a DSN

### DIFF
--- a/.changeset/bright-actors-begin.md
+++ b/.changeset/bright-actors-begin.md
@@ -1,0 +1,7 @@
+---
+'@spotlightjs/sidecar': minor
+'@spotlightjs/electron': minor
+'@spotlightjs/spotlight': minor
+---
+
+Add ability to use sidecar URL in a DSN

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -101,7 +101,7 @@ function handleStreamRequest(
     }
     return true;
   } else {
-    if (req.url == '/stream') {
+    if (req.url == '/stream' || (req.url && /^\/api\/\d+\/envelope/.test(req.url))) {
       if (req.method === 'OPTIONS') {
         res.writeHead(204, {
           'Cache-Control': 'no-cache',


### PR DESCRIPTION
Closes #450. With this, one may use `https://spotlight@localhost:8969/0` as a DSN for an SDK that does not support Spotlight itself.
