### PR TITLE
feat: Move contextlines code to sidecar

### DIFF
--- a/.changeset/great-chairs-grab.md
+++ b/.changeset/great-chairs-grab.md
@@ -1,0 +1,7 @@
+---
+'@spotlightjs/spotlight': minor
+'@spotlightjs/overlay': minor
+'@spotlightjs/sidecar': minor
+---
+
+Move contextlines provider to sidecar

--- a/packages/overlay/package.json
+++ b/packages/overlay/package.json
@@ -32,6 +32,7 @@
     "@sentry/types": "^8.0.0-alpha.7",
     "@sentry/utils": "^8.0.0-alpha.7",
     "@spotlightjs/tsconfig": "workspace:*",
+    "@spotlightjs/sidecar": "workspace:*",
     "@types/react": "^18.2.37",
     "@types/react-dom": "^18.2.15",
     "@typescript-eslint/eslint-plugin": "^6.0.0",

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -58,10 +58,8 @@ export default function App({
   const navigate = useNavigate();
 
   const clearEvents = () => {
-    const sidecarUrlObject: URL = new URL(sidecarUrl);
-    const host: string = sidecarUrlObject?.hostname;
-    const port: string = sidecarUrlObject?.port;
-    const clearEventsUrl: string = `http://${host}:${port}/clear`;
+    const { origin } = new URL(sidecarUrl);
+    const clearEventsUrl: string = `${origin}/clear`;
 
     fetch(clearEventsUrl, {
       method: 'DELETE',

--- a/packages/overlay/src/constants.ts
+++ b/packages/overlay/src/constants.ts
@@ -5,5 +5,3 @@ export const DEFAULT_EXPERIMENTS = {
 };
 
 export const DEFAULT_ANCHOR = 'bottomRight';
-
-export const CONTEXT_LINES_ENDPOINT = '/@spotlight/contextlines';

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -1,8 +1,9 @@
 import fontStyles from '@fontsource/raleway/index.css?inline';
+import { CONTEXT_LINES_ENDPOINT } from '@spotlightjs/sidecar/constants';
 import { MemoryRouter } from 'react-router-dom';
 import colors from 'tailwindcss/colors';
 import App from './App.tsx';
-import { CONTEXT_LINES_ENDPOINT, DEFAULT_ANCHOR, DEFAULT_EXPERIMENTS, DEFAULT_SIDECAR_URL } from './constants.ts';
+import { DEFAULT_ANCHOR, DEFAULT_EXPERIMENTS, DEFAULT_SIDECAR_URL } from './constants.ts';
 import globalStyles from './index.css?inline';
 import { initIntegrations, type SpotlightContext } from './integrations/integration.ts';
 import { default as sentry } from './integrations/sentry/index.ts';

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -2,6 +2,7 @@ import { Envelope } from '@sentry/types';
 import { CONTEXT_LINES_ENDPOINT } from '@spotlightjs/sidecar/constants';
 import { DEFAULT_SIDECAR_URL } from '~/constants';
 import { RawEventContext } from '~/integrations/integration';
+import { log } from '../../../lib/logger';
 import { generate_uuidv4 } from '../../../lib/uuid';
 import { Sdk, SentryErrorEvent, SentryEvent, SentryTransactionEvent, Span, Trace } from '../types';
 import { getNativeFetchImplementation } from '../utils/fetch';
@@ -289,7 +290,7 @@ class SentryDataCache {
           !exception.stacktrace ||
           exception.stacktrace.frames?.every(frame => frame.post_context && frame.pre_context && frame.context_line)
         ) {
-          console.log('skipping', exception);
+          log('Skipping contextlines request for', exception);
           return;
         }
         exception.stacktrace.frames.reverse();

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -1,6 +1,7 @@
 import { Envelope } from '@sentry/types';
+import { CONTEXT_LINES_ENDPOINT } from '@spotlightjs/sidecar/constants';
+import { DEFAULT_SIDECAR_URL } from '~/constants';
 import { RawEventContext } from '~/integrations/integration';
-import { CONTEXT_LINES_ENDPOINT } from '../../../constants';
 import { generate_uuidv4 } from '../../../lib/uuid';
 import { Sdk, SentryErrorEvent, SentryEvent, SentryTransactionEvent, Span, Trace } from '../types';
 import { getNativeFetchImplementation } from '../utils/fetch';
@@ -32,12 +33,19 @@ class SentryDataCache {
 
   protected subscribers: Map<string, Subscription> = new Map();
 
+  protected contextLinesProvider: string = new URL(DEFAULT_SIDECAR_URL).origin + CONTEXT_LINES_ENDPOINT;
+
   constructor(
     initial: (SentryEvent & {
       event_id?: string;
     })[] = [],
   ) {
     initial.forEach(e => this.pushEvent(e));
+  }
+
+  setSidecarUrl(url: string) {
+    const { origin } = new URL(url);
+    this.contextLinesProvider = origin + CONTEXT_LINES_ENDPOINT;
   }
 
   inferSdkFromEvent(event: SentryEvent) {
@@ -112,7 +120,7 @@ class SentryDataCache {
     if (this.eventIds.has(event.event_id)) return;
 
     if (isErrorEvent(event)) {
-      await processStacktrace(event);
+      await this.processStacktrace(event);
     }
 
     event.timestamp = toTimestamp(event.timestamp);
@@ -264,51 +272,51 @@ class SentryDataCache {
     if (this.localTraceIds.size > 0) return false;
     return null;
   }
+
+  /**
+   * Reverses the stack trace and tries to fill missing context lines
+   * @param errorEvent
+   * @returns
+   */
+  async processStacktrace(errorEvent: SentryErrorEvent): Promise<void[]> {
+    if (!errorEvent.exception || !errorEvent.exception.values) {
+      return [];
+    }
+
+    return Promise.all(
+      (errorEvent.exception.values ?? []).map(async exception => {
+        if (
+          !exception.stacktrace ||
+          exception.stacktrace.frames?.every(frame => frame.post_context && frame.pre_context && frame.context_line)
+        ) {
+          console.log('skipping', exception);
+          return;
+        }
+        exception.stacktrace.frames.reverse();
+
+        try {
+          const makeFetch = getNativeFetchImplementation();
+          const stackTraceWithContextResponse = await makeFetch(this.contextLinesProvider, {
+            method: 'PUT',
+            body: JSON.stringify(exception.stacktrace),
+          });
+
+          if (!stackTraceWithContextResponse.ok || stackTraceWithContextResponse.status !== 200) {
+            return;
+          }
+
+          const stackTraceWithContext = await stackTraceWithContextResponse.json();
+          exception.stacktrace = stackTraceWithContext;
+        } catch {
+          // Something went wrong, for now we just ignore it.
+        }
+      }),
+    );
+  }
 }
 
 export default new SentryDataCache();
 
 function isErrorEvent(event: SentryEvent): event is SentryErrorEvent {
   return event.type != 'transaction';
-}
-
-/**
- * Reverses the stack trace and tries to fill missing context lines
- * @param errorEvent
- * @returns
- */
-async function processStacktrace(errorEvent: SentryErrorEvent): Promise<void[]> {
-  if (!errorEvent.exception || !errorEvent.exception.values) {
-    return [];
-  }
-
-  return Promise.all(
-    (errorEvent.exception.values ?? []).map(async exception => {
-      if (
-        !exception.stacktrace ||
-        exception.stacktrace.frames?.every(frame => frame.post_context && frame.pre_context && frame.context_line)
-      ) {
-        console.log('skipping', exception);
-        return;
-      }
-      exception.stacktrace.frames.reverse();
-
-      try {
-        const makeFetch = getNativeFetchImplementation();
-        const stackTraceWithContextResponse = await makeFetch(CONTEXT_LINES_ENDPOINT, {
-          method: 'PUT',
-          body: JSON.stringify(exception.stacktrace),
-        });
-
-        if (!stackTraceWithContextResponse.ok || stackTraceWithContextResponse.status !== 200) {
-          return;
-        }
-
-        const stackTraceWithContext = await stackTraceWithContextResponse.json();
-        exception.stacktrace = stackTraceWithContext;
-      } catch {
-        // Something went wrong, for now we just ignore it.
-      }
-    }),
-  );
 }

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -29,9 +29,12 @@ export default function sentryIntegration(options: SentryIntegrationOptions = {}
       if (options.retries == null) {
         options.retries = 3;
       }
+      if (options.sidecarUrl) {
+        sentryDataCache.setSidecarUrl(options.sidecarUrl);
+      }
       addSpotlightIntegrationToSentry(options);
 
-      if (options?.openLastError) {
+      if (options.openLastError) {
         sentryDataCache.subscribe('event', (e: SentryEvent) => {
           if (!(e as SentryErrorEvent).exception) return;
           setTimeout(() => open(`/errors/${e.event_id}`), 0);

--- a/packages/overlay/src/integrations/sentry/sentry-integration.ts
+++ b/packages/overlay/src/integrations/sentry/sentry-integration.ts
@@ -1,5 +1,6 @@
 import { Client, Envelope, Event, Integration } from '@sentry/types';
 import { serializeEnvelope } from '@sentry/utils';
+import { DEFAULT_SIDECAR_URL } from '~/constants';
 import { log } from '../../lib/logger';
 import sentryDataCache from './data/sentryDataCache';
 import { getNativeFetchImplementation } from './utils/fetch';
@@ -7,9 +8,9 @@ import { getNativeFetchImplementation } from './utils/fetch';
 type SpotlightBrowserIntegrationOptions = {
   /**
    * The URL of the Sidecar instance to connect and forward events to.
-   * If not set, Spotlight will try to connect to the Sidecar running on localhost:8969.
+   * If not set, Spotlight will try to connect to the Sidecar running on DEFAULT_SIDECAR_URL.
    *
-   * @default "http://localhost:8969/stream"
+   * @default DEFAULT_SIDECAR_URL
    */
   sidecarUrl?: string;
 };
@@ -29,7 +30,7 @@ type SpotlightBrowserIntegrationOptions = {
  * @returns Sentry integration for Spotlight.
  */
 export const spotlightIntegration = (options?: SpotlightBrowserIntegrationOptions) => {
-  const _sidecarUrl = options?.sidecarUrl ?? 'http://localhost:8969/stream';
+  const _sidecarUrl = options?.sidecarUrl ?? DEFAULT_SIDECAR_URL;
 
   return {
     name: 'SpotlightBrowser',

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -28,12 +28,17 @@
     "./vite-plugin": {
       "import": "./src/vite-plugin.js"
     },
+    "./constants": {
+      "import": "./src/constants.js",
+      "types": "./dist/constants.d.ts"
+    },
     "./run": {
       "import": "./src/run.js"
     }
   },
   "dependencies": {},
   "devDependencies": {
+    "source-map": "^0.7.4",
     "kleur": "^4.1.5",
     "@spotlightjs/tsconfig": "workspace:*",
     "@types/node": "^18",

--- a/packages/sidecar/src/constants.ts
+++ b/packages/sidecar/src/constants.ts
@@ -1,0 +1,3 @@
+export const DEFAULT_PORT = 8969;
+export const SERVER_IDENTIFIER = 'spotlight-by-sentry';
+export const CONTEXT_LINES_ENDPOINT = '/contextlines';

--- a/packages/sidecar/src/contextlines.ts
+++ b/packages/sidecar/src/contextlines.ts
@@ -1,0 +1,186 @@
+import { readFileSync } from 'node:fs';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import * as os from 'node:os';
+import * as SourceMap from 'source-map';
+
+type SourceContext = {
+  pre_context?: string[];
+  context_line?: string;
+  post_context?: string[];
+};
+
+type SentryStackFrame = {
+  filename?: string;
+  lineno?: number;
+  colno?: number;
+} & SourceContext;
+
+type ValidSentryStackFrame = Required<SentryStackFrame>;
+
+type SentryStackTrace = {
+  frames?: SentryStackFrame[];
+};
+
+async function getGeneratedCodeFromServer(filename: string): Promise<string | undefined> {
+  try {
+    const generatedCodeResponse = await fetch(filename);
+    return generatedCodeResponse.text();
+  } catch {
+    return undefined;
+  }
+}
+
+function parseStackTrace(requestBody: string): SentryStackTrace | undefined {
+  try {
+    return JSON.parse(requestBody) as SentryStackTrace;
+  } catch {
+    return undefined;
+  }
+}
+
+async function applySourceContextToFrame(sourceMapContent: string, frame: ValidSentryStackFrame) {
+  const consumer = await new SourceMap.SourceMapConsumer(sourceMapContent);
+
+  const originalPosition = consumer.originalPositionFor({
+    line: frame.lineno,
+    column: frame.colno,
+    bias: SourceMap.SourceMapConsumer.LEAST_UPPER_BOUND,
+  });
+
+  if (originalPosition.source && originalPosition.line && originalPosition.column) {
+    frame.lineno = originalPosition.line;
+    frame.colno = originalPosition.column;
+    const content = consumer.sourceContentFor(originalPosition.source);
+    const lines = content?.split(os.EOL) ?? [];
+    addContextLinesToFrame(lines, frame);
+  }
+
+  return originalPosition;
+}
+
+function addContextLinesToFrame(lines: string[], frame: ValidSentryStackFrame, linesOfContext: number = 5): void {
+  const maxLines = lines.length;
+  const sourceLine = Math.max(Math.min(maxLines - 1, frame.lineno - 1), 0);
+
+  frame.pre_context = lines
+    .slice(Math.max(0, sourceLine - linesOfContext), sourceLine)
+    .map((line: string) => snipLine(line, 0));
+
+  frame.context_line = snipLine(lines[Math.min(maxLines - 1, sourceLine)], frame.colno || 0);
+
+  frame.post_context = lines
+    .slice(Math.min(sourceLine + 1, maxLines), sourceLine + 1 + linesOfContext)
+    .map((line: string) => snipLine(line, 0));
+}
+
+/**
+ * This is basically just `trim_line` from
+ * https://github.com/getsentry/sentry/blob/master/src/sentry/lang/javascript/processor.py#L67
+ *
+ * @param str An object that contains serializable values
+ * @param max Maximum number of characters in truncated string
+ * @returns string Encoded
+ */
+function snipLine(line: string, colno: number): string {
+  let newLine = line;
+  const lineLength = newLine.length;
+  if (lineLength <= 150) {
+    return newLine;
+  }
+  if (colno > lineLength) {
+    // eslint-disable-next-line no-param-reassign
+    colno = lineLength;
+  }
+
+  let start = Math.max(colno - 60, 0);
+  if (start < 5) {
+    start = 0;
+  }
+
+  let end = Math.min(start + 140, lineLength);
+  if (end > lineLength - 5) {
+    end = lineLength;
+  }
+  if (end === lineLength) {
+    start = Math.max(end - 140, 0);
+  }
+
+  newLine = newLine.slice(start, end);
+  if (start > 0) {
+    newLine = `'{snip} ${newLine}`;
+  }
+  if (end < lineLength) {
+    newLine += ' {snip}';
+  }
+
+  return newLine;
+}
+
+function isValidSentryStackFrame(frame: SentryStackFrame): frame is ValidSentryStackFrame {
+  return !!frame.filename && !!frame.lineno && !!frame.colno;
+}
+
+export function contextLinesHandler(req: IncomingMessage, res: ServerResponse) {
+  // We're only interested in handling a PUT request to CONTEXT_LINES_ENDPOINT
+  if (req.method !== 'PUT') {
+    res.writeHead(405);
+    res.end();
+    return;
+  }
+
+  let requestBody = '';
+  req.on('data', chunk => {
+    requestBody += chunk;
+  });
+
+  req.on('end', async () => {
+    const stacktrace = parseStackTrace(requestBody);
+
+    if (!stacktrace) {
+      res.writeHead(500);
+      res.end();
+      return;
+    }
+
+    for (const frame of stacktrace.frames ?? []) {
+      if (
+        !isValidSentryStackFrame(frame) ||
+        // let's ignore dependencies for now with this naive check
+        frame.filename.includes('/node_modules/')
+      ) {
+        continue;
+      }
+      const { filename } = frame;
+      // Dirty check to see if this looks like a regular file path or a URL
+      if (filename.includes('://')) {
+        const generatedCode = await getGeneratedCodeFromServer(frame.filename);
+        if (!generatedCode) {
+          continue;
+        }
+
+        // Extract the inline source map from the minified code
+        const inlineSourceMapMatch = generatedCode.match(/\/\/# sourceMappingURL=data:application\/json;base64,(.*)/);
+
+        if (inlineSourceMapMatch && inlineSourceMapMatch[1]) {
+          const sourceMapBase64 = inlineSourceMapMatch[1];
+          const sourceMapContent = Buffer.from(sourceMapBase64, 'base64').toString('utf-8');
+          await applySourceContextToFrame(sourceMapContent, frame);
+        }
+      } else if (!filename.includes(':')) {
+        try {
+          const lines = readFileSync(filename, { encoding: 'utf-8' }).split(/\r?\n/);
+          addContextLinesToFrame(lines, frame);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+            throw err;
+          }
+        }
+      }
+    }
+
+    const responseJson = JSON.stringify(stacktrace);
+
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(responseJson);
+  });
+}

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -2,11 +2,10 @@ import { createWriteStream, readFile } from 'node:fs';
 import { IncomingMessage, Server, ServerResponse, createServer, get } from 'node:http';
 import { extname, join } from 'node:path';
 import { createGunzip, createInflate } from 'node:zlib';
+import { CONTEXT_LINES_ENDPOINT, DEFAULT_PORT, SERVER_IDENTIFIER } from './constants.js';
+import { contextLinesHandler } from './contextlines.js';
 import { SidecarLogger, activateLogger, enableDebugLogging, logger } from './logger.js';
 import { MessageBuffer } from './messageBuffer.js';
-
-const DEFAULT_PORT = 8969;
-const SERVER_IDENTIFIER = 'spotlight-by-sentry';
 
 type Payload = [string, string];
 
@@ -230,6 +229,7 @@ function startServer(
     [/^\/health$/, handleHealthRequest],
     [/^\/clear$/, handleClearRequest],
     [/^\/stream$|^\/api\/\d+\/envelope$/, streamRequestHandler(buffer, incomingPayload)],
+    [RegExp(`^${CONTEXT_LINES_ENDPOINT}$`), contextLinesHandler],
     [/^.+$/, basePath != null ? fileServer(basePath) : error404],
   ];
 

--- a/packages/sidecar/vite.config.ts
+++ b/packages/sidecar/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
     outDir: './dist',
     sourcemap: true,
     rollupOptions: {
-      external: [...dependencies, 'node:path', 'node:http', 'node:fs', 'node:zlib'],
+      external: [...dependencies, 'node:path', 'node:http', 'node:zlib'],
     },
   },
   ssr: {

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@spotlightjs/overlay": "workspace:*",
     "@spotlightjs/sidecar": "workspace:*",
-    "source-map": "^0.7.4",
     "import-meta-resolve": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/spotlight/src/vite-plugin.ts
+++ b/packages/spotlight/src/vite-plugin.ts
@@ -1,35 +1,13 @@
 import { randomBytes } from 'node:crypto';
-import { readFileSync } from 'node:fs';
 import type { ServerResponse } from 'node:http';
 
 // Cannot use import.meta.resolve -- @see https://github.com/vitejs/vite/discussions/15871
 import type { SpotlightOverlayOptions } from '@spotlightjs/overlay';
-import { CONTEXT_LINES_ENDPOINT } from '@spotlightjs/overlay';
 import { resolve } from 'import-meta-resolve';
-import * as os from 'node:os';
-import * as SourceMap from 'source-map';
 import type { Connect, ErrorPayload, PluginOption, ViteDevServer } from 'vite';
 
 import * as packageJson from '../package.json';
 import { setupSidecar } from './sidecar';
-
-type SourceContext = {
-  pre_context?: string[];
-  context_line?: string;
-  post_context?: string[];
-};
-
-type SentryStackFrame = {
-  filename?: string;
-  lineno?: number;
-  colno?: number;
-} & SourceContext;
-
-type ValidSentryStackFrame = Required<SentryStackFrame>;
-
-type SentryStackTrace = {
-  frames?: SentryStackFrame[];
-};
 
 const FILE_PROTOCOL_PREFIX_LENGTH = 'file://'.length;
 
@@ -82,168 +60,6 @@ export function buildClientInit(options: SpotlightInitOptions) {
     `window.createErrorOverlay=function createErrorOverlay(err) { Spotlight.openSpotlight(); };`,
   ].join('\n');
 }
-
-async function getGeneratedCodeFromServer(filename: string): Promise<string | undefined> {
-  try {
-    const generatedCodeResponse = await fetch(filename);
-    return generatedCodeResponse.text();
-  } catch {
-    return undefined;
-  }
-}
-
-function parseStackTrace(requestBody: string): SentryStackTrace | undefined {
-  try {
-    return JSON.parse(requestBody) as SentryStackTrace;
-  } catch {
-    return undefined;
-  }
-}
-
-async function applySourceContextToFrame(sourceMapContent: string, frame: ValidSentryStackFrame) {
-  const consumer = await new SourceMap.SourceMapConsumer(sourceMapContent);
-
-  const originalPosition = consumer.originalPositionFor({
-    line: frame.lineno,
-    column: frame.colno,
-    bias: SourceMap.SourceMapConsumer.LEAST_UPPER_BOUND,
-  });
-
-  if (originalPosition.source && originalPosition.line && originalPosition.column) {
-    frame.lineno = originalPosition.line;
-    frame.colno = originalPosition.column;
-    const content = consumer.sourceContentFor(originalPosition.source);
-    const lines = content?.split(os.EOL) ?? [];
-    addContextLinesToFrame(lines, frame);
-  }
-
-  return originalPosition;
-}
-
-function addContextLinesToFrame(lines: string[], frame: ValidSentryStackFrame, linesOfContext: number = 5): void {
-  const maxLines = lines.length;
-  const sourceLine = Math.max(Math.min(maxLines - 1, frame.lineno - 1), 0);
-
-  frame.pre_context = lines
-    .slice(Math.max(0, sourceLine - linesOfContext), sourceLine)
-    .map((line: string) => snipLine(line, 0));
-
-  frame.context_line = snipLine(lines[Math.min(maxLines - 1, sourceLine)], frame.colno || 0);
-
-  frame.post_context = lines
-    .slice(Math.min(sourceLine + 1, maxLines), sourceLine + 1 + linesOfContext)
-    .map((line: string) => snipLine(line, 0));
-}
-
-/**
- * This is basically just `trim_line` from
- * https://github.com/getsentry/sentry/blob/master/src/sentry/lang/javascript/processor.py#L67
- *
- * @param str An object that contains serializable values
- * @param max Maximum number of characters in truncated string
- * @returns string Encoded
- */
-function snipLine(line: string, colno: number): string {
-  let newLine = line;
-  const lineLength = newLine.length;
-  if (lineLength <= 150) {
-    return newLine;
-  }
-  if (colno > lineLength) {
-    // eslint-disable-next-line no-param-reassign
-    colno = lineLength;
-  }
-
-  let start = Math.max(colno - 60, 0);
-  if (start < 5) {
-    start = 0;
-  }
-
-  let end = Math.min(start + 140, lineLength);
-  if (end > lineLength - 5) {
-    end = lineLength;
-  }
-  if (end === lineLength) {
-    start = Math.max(end - 140, 0);
-  }
-
-  newLine = newLine.slice(start, end);
-  if (start > 0) {
-    newLine = `'{snip} ${newLine}`;
-  }
-  if (end < lineLength) {
-    newLine += ' {snip}';
-  }
-
-  return newLine;
-}
-
-function isValidSentryStackFrame(frame: SentryStackFrame): frame is ValidSentryStackFrame {
-  return !!frame.filename && !!frame.lineno && !!frame.colno;
-}
-
-export const sourceContextMiddleware: Connect.NextHandleFunction = function (req, res, next) {
-  // We're only interested in handling a PUT request to CONTEXT_LINES_ENDPOINT
-  if (req.url !== CONTEXT_LINES_ENDPOINT || req.method !== 'PUT') {
-    return next();
-  }
-
-  let requestBody = '';
-  req.on('data', chunk => {
-    requestBody += chunk;
-  });
-
-  req.on('end', async () => {
-    const stacktrace = parseStackTrace(requestBody);
-
-    if (!stacktrace) {
-      res.writeHead(500);
-      res.end();
-      return;
-    }
-
-    for (const frame of stacktrace.frames ?? []) {
-      if (
-        !isValidSentryStackFrame(frame) ||
-        // let's ignore dependencies for now with this naive check
-        frame.filename.includes('/node_modules/')
-      ) {
-        continue;
-      }
-      const { filename } = frame;
-      // Dirty check to see if this looks like a regular file path or a URL
-      if (filename.includes('://')) {
-        const generatedCode = await getGeneratedCodeFromServer(frame.filename);
-        if (!generatedCode) {
-          continue;
-        }
-
-        // Extract the inline source map from the minified code
-        const inlineSourceMapMatch = generatedCode.match(/\/\/# sourceMappingURL=data:application\/json;base64,(.*)/);
-
-        if (inlineSourceMapMatch && inlineSourceMapMatch[1]) {
-          const sourceMapBase64 = inlineSourceMapMatch[1];
-          const sourceMapContent = Buffer.from(sourceMapBase64, 'base64').toString('utf-8');
-          await applySourceContextToFrame(sourceMapContent, frame);
-        }
-      } else if (!filename.includes(':')) {
-        try {
-          const lines = readFileSync(filename, { encoding: 'utf-8' }).split(/\r?\n/);
-          addContextLinesToFrame(lines, frame);
-        } catch (err) {
-          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
-            throw err;
-          }
-        }
-      }
-    }
-
-    const responseJson = JSON.stringify(stacktrace);
-
-    res.writeHead(200, { 'Content-Type': 'application/json' });
-    res.end(responseJson);
-  });
-};
 
 async function sendErrorToSpotlight(err: ErrorPayload['err'], spotlightUrl: string = 'http://localhost:8969/stream') {
   if (!err.errors) {
@@ -323,7 +139,6 @@ export default function spotlight(options: SpotlightInitOptions = {}): PluginOpt
     },
     configureServer(server: ViteDevServer) {
       setupSidecar({ port: options.port });
-      server.middlewares.use(sourceContextMiddleware);
 
       spotlightPath = getSpotlightClientModulePath({ server });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
       '@sentry/utils':
         specifier: ^8.0.0-alpha.7
         version: 8.7.0
+      '@spotlightjs/sidecar':
+        specifier: workspace:*
+        version: link:../sidecar
       '@spotlightjs/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig
@@ -466,6 +469,9 @@ importers:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
+      source-map:
+        specifier: ^0.7.4
+        version: 0.7.4
       typescript:
         specifier: ^5.0.2
         version: 5.2.2
@@ -484,9 +490,6 @@ importers:
       import-meta-resolve:
         specifier: ^4.1.0
         version: 4.1.0
-      source-map:
-        specifier: ^0.7.4
-        version: 0.7.4
     devDependencies:
       '@spotlightjs/tsconfig':
         specifier: workspace:*
@@ -14496,7 +14499,6 @@ packages:
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
-    dev: false
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}


### PR DESCRIPTION
This change moves the contextlines provider to the sidecar from the Vite plugin opening it up to all SDKs and integrations, not just Vite-based ones. This also means we do not clobber Vite dev server's URL-space (not that it was a problem, but alas).

This required adding a setter to `SentryDataCache` class as it was used as a singleton from its module and handles the additional context line fetching per earlier PRs. It would be good to refactor this usage to make it more contained/encapsulated.

Closes #449.

