### PR TITLE
ref: Use `module.builtinModules for Vite externals

### DIFF
--- a/packages/sidecar/vite.config.ts
+++ b/packages/sidecar/vite.config.ts
@@ -1,3 +1,4 @@
+import { builtinModules } from 'node:module';
 import { defineConfig } from 'vite';
 
 import packageJson from './package.json';
@@ -15,7 +16,7 @@ export default defineConfig({
     outDir: './dist',
     sourcemap: true,
     rollupOptions: {
-      external: [...dependencies, 'node:path', 'node:http', 'node:zlib'],
+      external: [...dependencies, ...builtinModules.map(x => `node:${x}`)],
     },
   },
   ssr: {

--- a/packages/spotlight/vite.config.ts
+++ b/packages/spotlight/vite.config.ts
@@ -1,3 +1,4 @@
+import { builtinModules } from 'node:module';
 import { resolve } from 'path';
 import { defineConfig } from 'vite';
 
@@ -20,7 +21,7 @@ export default defineConfig({
       //   fileName: 'sentry-spotlight',
     },
     rollupOptions: {
-      external: [...dependencies, 'node:path', 'node:crypto', 'node:fs'],
+      external: [...dependencies, ...builtinModules.map(x => `node:${x}`)],
     },
   },
 });


### PR DESCRIPTION
Closes #441.
