### PR TITLE
fix: Fix npx @spotlightjs/spotlight

### DIFF
--- a/.changeset/blue-foxes-serve.md
+++ b/.changeset/blue-foxes-serve.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': patch
+---
+
+Fix `npx @spotlightjs/spotlight` not running standalone overlay

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -16,7 +16,7 @@
     "bin"
   ],
   "bin": {
-    "spotlight-sidecar": "./bin/run.js"
+    "spotlight": "./bin/run.js"
   },
   "main": "./dist/overlay.cjs",
   "module": "./dist/overlay.js",


### PR DESCRIPTION
Due to a binary name clash between @spotlightjs/spotlight and @spotlightjs/sidecar (which is a dependency of the former), `npx @spotlightjs/spotlight` was running the binary from the sidecar, which does not have the standalone overlay. This PR fixes the issue by renaming the `@spotlightjs/spotlight` binary name to `spotlight` (from `spotlight-sidecar`).

Fixes #385.
