### PR TITLE
ci: Use GH_RELEASE_PAT for prepare-publish

### DIFF
--- a/.github/workflows/prepare-publish.yml
+++ b/.github/workflows/prepare-publish.yml
@@ -33,4 +33,4 @@ jobs:
           commit: 'meta(changelog): Update package versions'
           title: 'meta(changelog): Update package versions'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}


### PR DESCRIPTION
GitHub Actions forbids running subsequent actions for things triggered by the default `GITHUB_TOKEN` to prevent runaway costs. This prevents the builds from running on PRs created by the prepare-publish action, requiring forced-admin priviledgles to merge these PRs due to branch protection rules. This PR switches to the org-wide `GH_RELEASE_PAT` so the CI builds are triggered.
