### PR TITLE
fix: Move dependencies from devDependencies for sidecar

### DIFF
--- a/.changeset/chatty-cobras-end.md
+++ b/.changeset/chatty-cobras-end.md
@@ -1,0 +1,8 @@
+---
+'@spotlightjs/sidecar': patch
+'@spotlightjs/astro': patch
+'@spotlightjs/electron': patch
+'@spotlightjs/spotlight': patch
+---
+
+Fix dependency issues with sidecar

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -37,13 +37,14 @@
       "import": "./src/run.js"
     }
   },
-  "dependencies": {},
+  "dependencies": {
+    "launch-editor": "^2.8.0",
+    "source-map": "^0.7.4",
+    "kleur": "^4.1.5"
+  },
   "devDependencies": {
     "@spotlightjs/tsconfig": "workspace:*",
-    "launch-editor": "^2.8.0",
     "@types/node": "^18",
-    "kleur": "^4.1.5",
-    "source-map": "^0.7.4",
     "typescript": "^5.0.2",
     "vite": "^4.5.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,13 +459,7 @@ importers:
         version: 0.34.6
 
   packages/sidecar:
-    devDependencies:
-      '@spotlightjs/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
-      '@types/node':
-        specifier: ^18
-        version: 18.0.0
+    dependencies:
       kleur:
         specifier: ^4.1.5
         version: 4.1.5
@@ -475,6 +469,13 @@ importers:
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
+    devDependencies:
+      '@spotlightjs/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^18
+        version: 18.0.0
       typescript:
         specifier: ^5.0.2
         version: 5.2.2
@@ -11018,7 +11019,7 @@ packages:
     dependencies:
       picocolors: 1.0.1
       shell-quote: 1.8.1
-    dev: true
+    dev: false
 
   /lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -14329,7 +14330,7 @@ packages:
 
   /shell-quote@1.8.1:
     resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
-    dev: true
+    dev: false
 
   /shiki@0.14.5:
     resolution: {integrity: sha512-1gCAYOcmCFONmErGTrS1fjzJLA7MGZmKzrBNX7apqSwhyITJg2O102uFzXUeBxNnEkDA9vHIKLyeKq0V083vIw==}
@@ -14513,6 +14514,7 @@ packages:
   /source-map@0.7.4:
     resolution: {integrity: sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==}
     engines: {node: '>= 8'}
+    dev: false
 
   /space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}


### PR DESCRIPTION
This was causing crashes as these dependencies were declared as external so needs to be installed.
