### PR TITLE
feat: Add `#debug` flag to standalone spotlight web UI

### DIFF
--- a/.changeset/loud-melons-rescue.md
+++ b/.changeset/loud-melons-rescue.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': minor
+---
+
+Add `#debug` flag to standalone Spotlight web UI

--- a/packages/spotlight/src/index.html
+++ b/packages/spotlight/src/index.html
@@ -23,6 +23,7 @@
       Spotlight.init({
         fullPage: true,
         injectImmediately: true,
+        debug: document.URL.toLowerCase().endsWith('#debug'),
         showTriggerButton: false,
       });
     </script>


### PR DESCRIPTION
This enables the `debug` flag on Spotlight init for debugging.
