### PR TITLE
fix: Fix logical mistakes in integration event processing

### DIFF
--- a/.changeset/lovely-chefs-attend.md
+++ b/.changeset/lovely-chefs-attend.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fix event processing pipeline for integrations


### PR DESCRIPTION
We had multiple logical mistakes, such as not matching on lower-cased content type headers or skipping the entire event handler when a single integration did not define an event processor. This PR fixes these logical issues.
