### PR TITLE
feat: Auto-correct Sentry Browser SDK content type

### DIFF
--- a/.changeset/pink-buses-burn.md
+++ b/.changeset/pink-buses-burn.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/sidecar': minor
+---
+
+Auto-correct Sentry Browser SDK content type & fix URL matching with query string


### PR DESCRIPTION
This PR automatically corrects Sentry Browser SDK events' content type as it avoids using the standard `application/x-sentry-envelope` for CORS reasons. This also comes with the side effect of fixing URL parsing when it contains a query string or when a content-type header is not set.
