### PR TITLE
feat: Add IIFE bundle for single script include

### DIFF
--- a/.changeset/short-pugs-laugh.md
+++ b/.changeset/short-pugs-laugh.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': minor
+---
+
+Add IIFE for auto load & init over CDN with a single script include

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,13 @@
     "contextlines",
     "Endcaps",
     "fontsource",
+    "iife",
+    "outro",
     "pageload",
     "spotlightjs",
     "svgr",
     "tailwindcss",
+    "treeshake",
     "ttfb",
     "uuidv",
     "webvitals"

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -23,10 +23,10 @@ export {
   DEFAULT_ANCHOR,
   DEFAULT_EXPERIMENTS,
   DEFAULT_SIDECAR_URL,
-  off,
-  on,
   React,
   ReactDOM,
+  off,
+  on,
   trigger,
 };
 
@@ -179,7 +179,7 @@ export async function init({
     document.body.append(docRoot);
   }
 
-  if (injectImmediately) {
+  if (document.readyState === 'complete' || injectImmediately) {
     injectSpotlight();
   } else {
     window.addEventListener('load', () => {

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -175,6 +175,10 @@ export async function init({
   );
 
   function injectSpotlight() {
+    if (isSpotlightInjected()) {
+      log('Spotlight already injected, bailing.');
+      return;
+    }
     log('Injecting into application');
     document.body.append(docRoot);
   }
@@ -182,13 +186,7 @@ export async function init({
   if (document.readyState === 'complete' || injectImmediately) {
     injectSpotlight();
   } else {
-    window.addEventListener('load', () => {
-      injectSpotlight();
-    });
+    window.addEventListener('load', injectSpotlight);
   }
-  window.addEventListener('error', () => {
-    if (!isSpotlightInjected()) {
-      injectSpotlight();
-    }
-  });
+  window.addEventListener('error', injectSpotlight);
 }

--- a/packages/overlay/vite.config.ts
+++ b/packages/overlay/vite.config.ts
@@ -23,21 +23,6 @@ const removeReactDevToolsMessagePlugin: () => PluginOption = () => ({
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  // {
-  //   input: [ 'src/index.bundle.ts' ],
-  //   output: {
-  //     entryFileNames: [Function: entryFileNames],
-  //     dir: 'build',
-  //     sourcemap: true,
-  //     strict: false,
-  //     esModule: false,
-  //     format: 'iife',
-  //     name: 'Sentry',
-  //     intro: [Function: intro]
-  //   },
-  //   treeshake: 'smallest',
-  //   context: 'window'
-  // },
   plugins: [
     react(),
     dts({

--- a/packages/overlay/vite.config.ts
+++ b/packages/overlay/vite.config.ts
@@ -23,6 +23,21 @@ const removeReactDevToolsMessagePlugin: () => PluginOption = () => ({
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  // {
+  //   input: [ 'src/index.bundle.ts' ],
+  //   output: {
+  //     entryFileNames: [Function: entryFileNames],
+  //     dir: 'build',
+  //     sourcemap: true,
+  //     strict: false,
+  //     esModule: false,
+  //     format: 'iife',
+  //     name: 'Sentry',
+  //     intro: [Function: intro]
+  //   },
+  //   treeshake: 'smallest',
+  //   context: 'window'
+  // },
   plugins: [
     react(),
     dts({
@@ -48,9 +63,14 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.tsx'),
-      name: 'sentry-spotlight',
+      name: 'Spotlight',
       // the proper extensions will be added
       fileName: 'sentry-spotlight',
+      formats: ['es', 'iife'],
+    },
+    rollupOptions: {
+      treeshake: 'smallest',
+      output: { footer: 'window.Spotlight && Spotlight.init()' },
     },
     sourcemap: true,
   },

--- a/packages/website/src/content/docs/setup/html.mdx
+++ b/packages/website/src/content/docs/setup/html.mdx
@@ -5,30 +5,18 @@ description: Use the overlay directly in HTML
 
 To use Spotlight directly, you can load the script from a CDN and initialize it in a separate script tag.
 
-This solution will probably change in the future, as we are working on a better way to load Spotlight.
-
 ## Configuration
 
-```html {7, 10, 14-19}
+```html {6}
 <!doctype html>
 <html>
   <head>
     <title>Spotlight</title>
-    <!-- Set process for development environment -->
-    <script>
-      window.process = { env: { NODE_ENV: 'development' } };
-    </script>
     <!-- Load Spotlight.js from the CDN -->
-    <script type="module" src="https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js"></script>
+    <script src="https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.iife.js" crossorigin="anonymous"></script>
   </head>
   <body>
-    <!-- Import and initialize Spotlight in a separate script tag -->
-    <script type="module">
-      import * as Spotlight from 'https://unpkg.com/@spotlightjs/overlay@latest/dist/sentry-spotlight.js';
-      Spotlight.init({
-        openOnInit: true,
-      });
-    </script>
+    Your app
   </body>
 </html>
 ```


### PR DESCRIPTION
This change adds an Immediately Invoked Function Expression (IIFE) bundle which automatically initializes Spotlight upon loading. Greatly simplifies the HTML include method for Spotlight.

It also fixes a bug where Spotlight won't be initialized if it loads after page `load` event and `injectImmediately` was not set to `true`.
