### PR TITLE
ci: Fix auto publishing to Docker & Electron

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       !cancelled()
-      && inputs.docker
+      && inputs.docker != false
       && (needs.npm.result == 'success' || needs.npm.result == 'skipped')
     steps:
       - name: Checkout Repo
@@ -102,7 +102,7 @@ jobs:
     runs-on: macos-latest
     if: |
       !cancelled()
-      && inputs.electron
+      && inputs.electron != false
       && (needs.npm.result == 'success' || needs.npm.result == 'skipped')
     # strategy:
     #   fail-fast: false


### PR DESCRIPTION
As seen from #484, we don't automatically publish to Docker and Electron targets. The reason for this is we have an strict `inputs.docker` and `inputs.electron` check, assuming they will have a default value of `true`. That said the `input` context only gets populated on a manually triggered workflow, hence these jobs get skipped on auto publish actions. This PR should fix the issue by replacing it with an explicit `!= false` check, so it becomes `true` if the value is `null` or `undefined`.
