### PR TITLE
fix: Fix forgotton Sentry SDK migration in renderer

### DIFF
--- a/.changeset/flat-numbers-cheat.md
+++ b/.changeset/flat-numbers-cheat.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/electron': patch
+---
+
+Fix Sentry init error at startup

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -4,9 +4,8 @@ import * as Spotlight from '@spotlightjs/overlay';
 Sentry.init({
   dsn: 'https://192df1a78878de014eb416a99ff70269@o1.ingest.sentry.io/4506400311934976',
   integrations: [
-    new Sentry.BrowserTracing(),
-    // new Sentry.BrowserProfilingIntegration(),
-    new Sentry.Replay({
+    Sentry.browserTracingIntegration(),
+    Sentry.replayIntegration({
       // Additional SDK configuration goes in here, for example:
       maskAllText: true,
       blockAllMedia: true,


### PR DESCRIPTION
Should fix the last issue with #484