### PR TITLE
ci: Fix Docker publish run fail on auto

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -85,7 +85,7 @@ jobs:
         with:
           context: .
           cache-from: type=gha,scope=prod
-          no-cache: ${{ inputs.nocache }}
+          no-cache: ${{ inputs.nocache == true }}
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |


### PR DESCRIPTION
As earlier fixes, since `inputs` context is not available, it comes out as empty which violates the schema of the action we are using as it expects a bool. This patch fixes the issue.
