### PR TITLE
feat(overlay): Allow to directly add sentry envelopes via trigger

### DIFF
--- a/.changeset/blue-trees-repeat.md
+++ b/.changeset/blue-trees-repeat.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': minor
+---
+
+feat: Allow to directly add sentry envelopes via trigger

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -50,7 +50,7 @@ export default function sentryIntegration(options: SentryIntegrationOptions = {}
 
       on('sentry:showError', onRenderError as EventListener);
 
-      const onAddEnvelope = (e: CustomEvent<RawEventContext>) => {
+      const onAddEnvelope = (e: CustomEvent<string | Buffer>) => {
         if (!e.detail) return;
         processEnvelope({
           contentType: HEADER,

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -52,7 +52,7 @@ export default function sentryIntegration(options: SentryIntegrationOptions = {}
       const onAddEnvelope = (e: CustomEvent) => {
         if (!e.detail.envelope) return;
         processEnvelope({
-          contentType: 'application/x-sentry-envelope',
+          contentType: HEADER,
           data: e.detail.envelope,
         });
       };

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -41,19 +41,20 @@ export default function sentryIntegration(options: SentryIntegrationOptions = {}
         });
       }
 
-      const onRenderError = (e: CustomEvent) => {
-        log('Sentry Event', e.detail.event_id);
-        if (!e.detail.event) return;
-        sentryDataCache.pushEvent(e.detail.event).then(() => open(`/errors/${e.detail.event.event_id}`));
+      const onRenderError = (e: CustomEvent<{ event?: SentryEvent; event_id: string }>) => {
+        const { event_id, event } = e.detail;
+        log('Sentry Event', event_id);
+        if (!event) return;
+        sentryDataCache.pushEvent(event).then(() => open(`/errors/${event.event_id}`));
       };
 
       on('sentry:showError', onRenderError as EventListener);
 
-      const onAddEnvelope = (e: CustomEvent) => {
-        if (!e.detail.envelope) return;
+      const onAddEnvelope = (e: CustomEvent<RawEventContext>) => {
+        if (!e.detail) return;
         processEnvelope({
           contentType: HEADER,
-          data: e.detail.envelope,
+          data: e.detail,
         });
       };
 

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -49,8 +49,19 @@ export default function sentryIntegration(options: SentryIntegrationOptions = {}
 
       on('sentry:showError', onRenderError as EventListener);
 
+      const onAddEnvelope = (e: CustomEvent) => {
+        if (!e.detail.envelope) return;
+        processEnvelope({
+          contentType: 'application/x-sentry-envelope',
+          data: e.detail.envelope,
+        });
+      };
+
+      on('sentry:addEnvelope', onAddEnvelope as EventListener);
+
       return () => {
         off('sentry:showError', onRenderError as EventListener);
+        off('sentry:addEnvelope', onAddEnvelope as EventListener);
       };
     },
 

--- a/packages/website/src/content/docs/reference/configuration.md
+++ b/packages/website/src/content/docs/reference/configuration.md
@@ -155,7 +155,7 @@ import { trigger } from '@spotlightjs/spotlight';
 
 trigger('sentry:showError', {
   event: string,
-  eventId: string,
+  event_id: string,
 });
 ```
 

--- a/packages/website/src/content/docs/reference/sentry.mdx
+++ b/packages/website/src/content/docs/reference/sentry.mdx
@@ -16,10 +16,18 @@ init({
 Additionally it includes an event to trigger synchronously rendering an error:
 
 ```js
-import { trigger } as Spotlight from '@spotlightjs/spotlight';
+import { trigger } from '@spotlightjs/spotlight';
 
 trigger("sentry:showError", {
   eventId: string,
   event?: Event,
 });
+```
+
+You can also directly add envelopes to the Sentry integration:
+
+```js
+import { trigger } from '@spotlightjs/spotlight';
+
+trigger("sentry:addEnvelope", sentryEnvelope);
 ```

--- a/packages/website/src/content/docs/reference/sentry.mdx
+++ b/packages/website/src/content/docs/reference/sentry.mdx
@@ -19,7 +19,7 @@ Additionally it includes an event to trigger synchronously rendering an error:
 import { trigger } from '@spotlightjs/spotlight';
 
 trigger("sentry:showError", {
-  eventId: string,
+  event_id: string,
   event?: Event,
 });
 ```


### PR DESCRIPTION
I am currently working on a hackweek project where I want to integrate the spotlight overlay into a chrome browser extension.

There, I cannot use sidecar (because I cannot launch a node service), but I can intercept envelopes sent to sentry myself. I'd like to be able to just run the spotlight overlay in the extension and directly push envelopes to it.

For this, I added a new hook, so you can add envelopes like this:

```
trigger("sentry:addEnvelope", sentryEnvelope);
```