### PR TITLE
ref: Fix up some tsconfig schenanigans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ junit.xml
 
 # Build artifacts
 *.tgz
+tsconfig.tsbuildinfo

--- a/packages/astro/src/index.ts
+++ b/packages/astro/src/index.ts
@@ -2,8 +2,8 @@ import type { SpotlightInitOptions } from '@spotlightjs/spotlight/vite-plugin';
 import type { AstroConfig, AstroIntegration } from 'astro';
 import { buildServerSnippet } from './snippets';
 
-import path from 'path';
-import url from 'url';
+import path from 'node:path';
+import url from 'node:url';
 
 import spotlight, { buildClientInit } from '@spotlightjs/spotlight/vite-plugin';
 

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -44,9 +44,9 @@ export default function App({
       }
     }
 
-    const result: Record<string, (event: { data: string | Buffer }) => void> = Object.create(null);
+    const result: Record<string, (event: { data: string | Uint8Array }) => void> = Object.create(null);
     for (const [contentType, integrations] of contentTypeToIntegrations.entries()) {
-      const listener = (event: { data: string | Buffer }): void => {
+      const listener = (event: { data: string | Uint8Array }): void => {
         log(`Received new ${contentType} event`);
         for (const integration of integrations) {
           const newIntegrationData = integration.processEvent

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -2,22 +2,22 @@ import fontStyles from '@fontsource/raleway/index.css?inline';
 import { CONTEXT_LINES_ENDPOINT } from '@spotlightjs/sidecar/constants';
 import { MemoryRouter } from 'react-router-dom';
 import colors from 'tailwindcss/colors';
-import App from './App.tsx';
-import { DEFAULT_ANCHOR, DEFAULT_EXPERIMENTS, DEFAULT_SIDECAR_URL } from './constants.ts';
+import App from './App';
+import { DEFAULT_ANCHOR, DEFAULT_EXPERIMENTS, DEFAULT_SIDECAR_URL } from './constants';
 import globalStyles from './index.css?inline';
-import { initIntegrations, type SpotlightContext } from './integrations/integration.ts';
-import { default as sentry } from './integrations/sentry/index.ts';
-import { off, on, trigger } from './lib/eventTarget.ts';
-import { activateLogger, log } from './lib/logger.ts';
-import { SpotlightContextProvider } from './lib/useSpotlightContext.tsx';
-import { React, ReactDOM } from './react-instance.tsx'; // Import specific exports
-import type { SpotlightOverlayOptions, WindowWithSpotlight } from './types.ts';
+import { initIntegrations, type SpotlightContext } from './integrations/integration';
+import { default as sentry } from './integrations/sentry/index';
+import { off, on, trigger } from './lib/eventTarget';
+import { activateLogger, log } from './lib/logger';
+import { SpotlightContextProvider } from './lib/useSpotlightContext';
+import { React, ReactDOM } from './react-instance'; // Import specific exports
+import type { SpotlightOverlayOptions, WindowWithSpotlight } from './types';
 
-export { default as console } from './integrations/console/index.ts';
-export { default as hydrationError } from './integrations/hydration-error/index.ts';
-export { default as sentry } from './integrations/sentry/index.ts';
-export { default as viteInspect } from './integrations/vite-inspect/index.ts';
-export type { SpotlightOverlayOptions, WindowWithSpotlight } from './types.ts';
+export { default as console } from './integrations/console/index';
+export { default as hydrationError } from './integrations/hydration-error/index';
+export { default as sentry } from './integrations/sentry/index';
+export { default as viteInspect } from './integrations/vite-inspect/index';
+export type { SpotlightOverlayOptions, WindowWithSpotlight } from './types';
 export {
   CONTEXT_LINES_ENDPOINT,
   DEFAULT_ANCHOR,

--- a/packages/overlay/src/integrations/integration.ts
+++ b/packages/overlay/src/integrations/integration.ts
@@ -1,5 +1,5 @@
-import { type ComponentType } from 'react';
-import { type ExperimentsConfig, type NotificationCount } from '~/types';
+import type { ComponentType } from 'react';
+import type { ExperimentsConfig, NotificationCount } from '../types';
 
 export type SpotlightContext = {
   open: (path: string | undefined) => void;
@@ -114,7 +114,7 @@ export type RawEventContext = {
    *
    * Return the processed object or undefined if the event should be ignored.
    */
-  data: string | Buffer;
+  data: string | Uint8Array;
 };
 
 type TeardownFunction = () => void | Promise<() => void>;
@@ -122,7 +122,7 @@ type TeardownFunction = () => void | Promise<() => void>;
 // export type IntegrationParameter = Array<Integration<unknown>>;
 
 export async function initIntegrations(
-  integrations: Integration[] = [],
+  integrations: Integration[],
   context: SpotlightContext,
 ): Promise<[Integration[], TeardownFunction[]]> {
   if (!integrations) {

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.spec.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'vitest';
-import sentryDataCache from '~/integrations/sentry/data/sentryDataCache';
-import { processEnvelope } from '~/integrations/sentry/index';
+import { processEnvelope } from '../index';
+import sentryDataCache from './sentryDataCache';
 
-import fs from 'fs';
+import fs from 'node:fs';
 
 describe('SentryDataCache', () => {
   // We need to refactor this to make it actually testable

--- a/packages/overlay/src/integrations/sentry/index.spec.ts
+++ b/packages/overlay/src/integrations/sentry/index.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from 'vitest';
-import { processEnvelope } from '~/integrations/sentry/index';
+import { processEnvelope } from './index';
 
-import { Event } from '@sentry/types';
-import fs from 'fs';
-import sentryDataCache from '~/integrations/sentry/data/sentryDataCache';
+import type { Event } from '@sentry/types';
+import fs from 'node:fs';
+import sentryDataCache from './data/sentryDataCache';
 
 describe('Sentry Integration', () => {
   test('Process Envelope Empty', () => {

--- a/packages/overlay/src/integrations/sentry/utils/traces.spec.ts
+++ b/packages/overlay/src/integrations/sentry/utils/traces.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
-import { Span } from '~/integrations/sentry/types';
-import { groupSpans } from '~/integrations/sentry/utils/traces';
-import { generate_uuidv4 } from '~/lib/uuid';
+import { generate_uuidv4 } from '../../../lib/uuid';
+import type { Span } from '../types';
+import { groupSpans } from './traces';
 
 function mockSpan({ duration, ...span }: Partial<Span> & { duration?: number } = {}): Span {
   const defaultTimestamp = new Date().getTime();

--- a/packages/overlay/tsconfig.json
+++ b/packages/overlay/tsconfig.json
@@ -4,8 +4,10 @@
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]
-    }
+    },
+    "outDir": "dist",
+    "rootDir": "src"
   },
-  "include": ["src", "test"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/overlay/tsconfig.json
+++ b/packages/overlay/tsconfig.json
@@ -8,6 +8,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src", "test"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/overlay/tsconfig.json
+++ b/packages/overlay/tsconfig.json
@@ -8,6 +8,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
+  "include": ["src", "test"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/overlay/vitest.config.ts
+++ b/packages/overlay/vitest.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
       reporter: ['json'],
     },
     globals: true,
-    include: ['./test/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    include: ['./src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     watchExclude: ['.*\\/node_modules\\/.*', '.*\\/dist\\/.*'],
   },
   resolve: {

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "./server.js",
     "dev": "vite build --watch",
-    "build": "vite build && tsc",
+    "build": "vite build && tsc --build",
     "build:watch": "vite build --watch",
     "clean": "rimraf dist"
   },

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "./server.js",
     "dev": "vite build --watch",
-    "build": "vite build && tsc --build",
+    "build": "vite build && tsc",
     "build:watch": "vite build --watch",
     "clean": "rimraf dist"
   },

--- a/packages/sidecar/tsconfig.json
+++ b/packages/sidecar/tsconfig.json
@@ -9,11 +9,9 @@
     "esModuleInterop": false,
     "target": "esnext",
     "module": "nodenext",
+    /* paths */
     "outDir": "dist",
-    "noEmit": false,
-    "allowImportingTsExtensions": false,
-    "declaration": true,
-    "emitDeclarationOnly": true
+    "rootDir": "src"
   },
   "include": ["src/*"]
 }

--- a/packages/spotlight/tsconfig.json
+++ b/packages/spotlight/tsconfig.json
@@ -3,12 +3,10 @@
   "compilerOptions": {
     "baseUrl": ".",
     "skipLibCheck": true,
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "noEmit": false,
+    /* paths */
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"],
+  "include": ["src", "test"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/spotlight/tsconfig.json
+++ b/packages/spotlight/tsconfig.json
@@ -7,6 +7,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src", "test"],
+  "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/tsconfig/tsconfig.json
+++ b/packages/tsconfig/tsconfig.json
@@ -5,13 +5,16 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "allowImportingTsExtensions": false,
+    /* cannot enable composite mode yet as vite clears output directory, requiring a tsc rebuild all the time */
+    "composite": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "noEmit": true,
     "jsx": "react-jsx",
 
     /* Linting */


### PR DESCRIPTION
This patch streamlines our `tsconfig`s across packages, always emitting `.d.ts` files (and only them) with using `src` as the root to avoid the `dist/src/something.d.ts` scenario entirely.

Got into this while trying to fix #354 elegantly but failed.