### PR TITLE
fix: Stacktraces not reversing when error has full context

### DIFF
--- a/.changeset/stale-jobs-give.md
+++ b/.changeset/stale-jobs-give.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fix stacktraces are not reversed sometimes (appearing in wrong order)

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -286,14 +286,17 @@ class SentryDataCache {
 
     return Promise.all(
       (errorEvent.exception.values ?? []).map(async exception => {
-        if (
-          !exception.stacktrace ||
-          exception.stacktrace.frames?.every(frame => frame.post_context && frame.pre_context && frame.context_line)
-        ) {
-          log('Skipping contextlines request for', exception);
+        if (!exception.stacktrace) {
           return;
         }
         exception.stacktrace.frames.reverse();
+
+        if (
+          exception.stacktrace.frames?.every(frame => frame.post_context && frame.pre_context && frame.context_line)
+        ) {
+          log('Skipping contextlines request as we have full context for', exception);
+          return;
+        }
 
         try {
           const makeFetch = getNativeFetchImplementation();


### PR DESCRIPTION
Fixes #489.
