### PR TITLE
fix: Fix infinite render loops for values from DB

### DIFF
--- a/.changeset/big-countries-explode.md
+++ b/.changeset/big-countries-explode.md
@@ -1,0 +1,8 @@
+---
+'@spotlightjs/overlay': patch
+'@spotlightjs/astro': patch
+'@spotlightjs/electron': patch
+'@spotlightjs/spotlight': patch
+---
+
+Fixed infinite render loops and optimized rerenders


### PR DESCRIPTION
This pach overhauls the initial rerender with better use of hooks, namely `useCallback` but also using intial state creation function to fix the infinite render loop reported in #521.

Fixes #521.
