### PR TITLE
fix: Mark event as seen as soon as we start processing

### DIFF
--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -119,6 +119,7 @@ class SentryDataCache {
     }
 
     if (this.eventIds.has(event.event_id)) return;
+    this.eventIds.add(event.event_id);
 
     if (isErrorEvent(event)) {
       await this.processStacktrace(event);
@@ -196,7 +197,6 @@ class SentryDataCache {
       this.subscribers.forEach(([type, cb]) => type === 'trace' && cb(trace));
     }
     this.subscribers.forEach(([type, cb]) => type === 'event' && cb(event));
-    this.eventIds.add(event.event_id);
   }
 
   getEvents() {


### PR DESCRIPTION
We delayed adding an event id to the 'seen' list until we tried to get more context about it, which is an async operation. This causes a race condition where the event was sent multiple times in rapid sucession to show the same event twice.

Fixes #526.
