### PR TITLE
feat: Add startFrom init option

### DIFF
--- a/packages/overlay/src/integrations/sentry/sentry-integration.ts
+++ b/packages/overlay/src/integrations/sentry/sentry-integration.ts
@@ -9,7 +9,7 @@ import sentryDataCache from './data/sentryDataCache';
  * This integration does the following:
  *
  *  - Drop transactions created from interactions with the Spotlight UI
- *  - Forward Sentry events sent from the browser SDK to the Sidecar instance running on
+ *  - Forward Sentry events sent from the browser SDK to the Spotlight instance running on
  *    the same page via the "direct message" method (w/o a need for the sidecar)
  *
  * @returns Sentry integration for Spotlight.

--- a/packages/overlay/src/types.ts
+++ b/packages/overlay/src/types.ts
@@ -106,8 +106,7 @@ export type SpotlightOverlayOptions = {
   initialEvents?: Record<string, (string | Uint8Array)[]>;
 
   /**
-   * Initial path to navigate to, instead of the main screen. Setting this will
-   * immediately call `open(startFrom)` upon app starting.
+   * Initial path to navigate to, instead of the first tab.
    */
   startFrom?: string;
 };

--- a/packages/overlay/src/types.ts
+++ b/packages/overlay/src/types.ts
@@ -104,6 +104,12 @@ export type SpotlightOverlayOptions = {
    * This is useful when replacing error pages of frameworks etc. Implies "injectImmediately".
    */
   initialEvents?: Record<string, (string | Uint8Array)[]>;
+
+  /**
+   * Initial path to navigate to, instead of the main screen. Setting this will
+   * immediately call `open(startFrom)` upon app starting.
+   */
+  startFrom?: string;
 };
 
 export type NotificationCount = {


### PR DESCRIPTION
Adds a `startFrom` init option to control the starting path of Spotlight app. This is useful to immediately display an error when we know will be there. The patch also fixes a bunch of init logic where `__spotlight.initOptions` were not being respected when custom init options are used. It also fixes `sentry()` integration getting initialized even if `integrations` did not include it.
