### PR TITLE
chore: Disable Sentry Replay masking on website

### DIFF
--- a/packages/website/sentry.client.config.mjs
+++ b/packages/website/sentry.client.config.mjs
@@ -8,8 +8,8 @@ Sentry.init({
   tracesSampleRate: 1.0,
   integrations: [
     Sentry.replayIntegration({
-      maskAllText: true,
-      blockAllMedia: true,
+      maskAllText: false,
+      blockAllMedia: false,
     }),
   ],
 });


### PR DESCRIPTION
This is a static website without any confidential information so disable masking for better replays in Sentry.
