### PR TITLE
fix: Sentry attribution in docs and overlay trigger minor bug fixed

### DIFF
--- a/.changeset/famous-olives-argue.md
+++ b/.changeset/famous-olives-argue.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fixed minor overlay trigger count issue

--- a/packages/overlay/src/components/Trigger.tsx
+++ b/packages/overlay/src/components/Trigger.tsx
@@ -35,7 +35,7 @@ function ToolbarItem({
     <div className="gap-x hover:bg-primary-400 relative flex items-center rounded p-3" {...props}>
       {children}
 
-      {count && (
+      {count ? (
         <span
           className={classNames(
             severe ? 'bg-red-500' : 'bg-primary-500',
@@ -44,7 +44,7 @@ function ToolbarItem({
         >
           {count}
         </span>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/packages/website/src/components/Footer.astro
+++ b/packages/website/src/components/Footer.astro
@@ -27,7 +27,7 @@
 </style>
 
 <div class="footer">
-  <span>Created by <a href="https://sentry.io">Sentry</a></span>
+  <span>Brought to you by <a href="https://sentry.io">Sentry</a></span>
   <span>Check it out on <a href="https://github.com/getsentry/spotlight">GitHub</a></span>
   <span>Visit us on <a href="https://discord.com/channels/621778831602221064/1176977569678114847">Discord</a></span>
 </div>

--- a/packages/website/src/components/Header.astro
+++ b/packages/website/src/components/Header.astro
@@ -13,8 +13,19 @@ const showSearch = Astro.props.slug !== '';
 ---
 
 <div class="header sl-flex">
-  <div class="sl-flex">
+  <div class="sl-flex items-center gap-x-1">
     <SiteTitle {...Astro.props} />
+    <div class="flex items-center gap-x-1 text-sm leading-5">
+      <span>by</span>
+      <a
+        rel="noopener"
+        href="https://sentry.io"
+        target="_blank"
+        class="no-underline text-inherit focus:outline-none font-medium hover:underline"
+      >
+        Sentry
+      </a>
+    </div>
   </div>
   <div class="sl-flex">
     {showSearch && <Search {...Astro.props} />}


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses

Fixes #243 
And a minor overlay trigger count issue - when 0 count on trigger we showing 0 with spotlight icon.