### PR TITLE
feat(spotlight): Stabilize embedded JS filename for external use

### DIFF
--- a/.changeset/ten-insects-pull.md
+++ b/.changeset/ten-insects-pull.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': minor
+---
+
+Stabilize embedded JS file name for local includes

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -23,10 +23,10 @@ export {
   DEFAULT_ANCHOR,
   DEFAULT_EXPERIMENTS,
   DEFAULT_SIDECAR_URL,
-  React,
-  ReactDOM,
   off,
   on,
+  React,
+  ReactDOM,
   trigger,
 };
 
@@ -107,18 +107,21 @@ export async function init(options: SpotlightOverlayOptions = {}) {
 
   const {
     openOnInit = false,
-    showTriggerButton = true,
-    injectImmediately = false,
     sidecarUrl = DEFAULT_SIDECAR_URL,
     anchor = DEFAULT_ANCHOR,
-    debug = false,
     integrations,
     experiments = DEFAULT_EXPERIMENTS,
-    fullPage = false,
     showClearEventsButton = true,
     initialEvents = undefined,
     startFrom = undefined,
   } = options;
+
+  const isLoadedFromSidecar = new URL(sidecarUrl).origin === document.location.origin;
+
+  const fullPage = options.fullPage ?? isLoadedFromSidecar;
+  const showTriggerButton = options.showTriggerButton ?? !fullPage;
+  const injectImmediately = options.injectImmediately ?? (isLoadedFromSidecar || fullPage);
+  const debug = options.debug ?? document.location.hash.endsWith('debug');
 
   if (debug) {
     activateLogger();

--- a/packages/spotlight/bin/run.js
+++ b/packages/spotlight/bin/run.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 const { setupSidecar } = await import('../dist/sidecar.js');
 const port = process.argv.length >= 3 ? Number(process.argv[2]) : undefined;
-import { join } from 'path';
-import { fileURLToPath } from 'url';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 setupSidecar({ port, basePath: join(fileURLToPath(import.meta.url), '../../dist/overlay/') });

--- a/packages/spotlight/src/index.html
+++ b/packages/spotlight/src/index.html
@@ -20,12 +20,7 @@
   <body>
     <script type="module">
       import * as Spotlight from '@spotlightjs/overlay';
-      Spotlight.init({
-        fullPage: true,
-        injectImmediately: true,
-        debug: document.URL.toLowerCase().endsWith('#debug'),
-        showTriggerButton: false,
-      });
+      Spotlight.init();
     </script>
   </body>
 </html>

--- a/packages/spotlight/vite.config.ts
+++ b/packages/spotlight/vite.config.ts
@@ -1,5 +1,5 @@
 import { builtinModules } from 'node:module';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 
 import packageJson from './package.json';

--- a/packages/spotlight/vite.overlay.config.ts
+++ b/packages/spotlight/vite.overlay.config.ts
@@ -8,6 +8,14 @@ export default defineConfig({
       input: {
         main: resolve(__dirname, 'src', 'index.html'),
       },
+      // We disable versioned filenames here explicitly
+      // so we can include the script when sidecar is running
+      // for server-side frameworks
+      output: {
+        entryFileNames: 'assets/[name].js',
+        chunkFileNames: 'assets/[name].js',
+        assetFileNames: 'assets/[name].[ext]',
+      },
     },
   },
 });


### PR DESCRIPTION
Fixes #552.

With this change one can now include Spotlight on any page locally from `http://localhost:8969/assets/main.js` (or wherever sidecar is running from).
