### PR TITLE
fix(overlay): UI fixes.

### DIFF
--- a/.changeset/big-radios-count.md
+++ b/.changeset/big-radios-count.md
@@ -2,5 +2,5 @@
 '@spotlightjs/overlay': patch
 ---
 
-- Fixed condition for showing open file in editor icon on error frame.
 - changed route and added navigation in performance tab to make queries tab default active.
+- Fixed showing of 0 in false condition in span details.

--- a/.changeset/big-radios-count.md
+++ b/.changeset/big-radios-count.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+- Fixed condition for showing open file in editor icon on error frame.
+- changed route and added navigation in performance tab to make queries tab default active.

--- a/packages/overlay/src/integrations/sentry/components/events/error/Frame.tsx
+++ b/packages/overlay/src/integrations/sentry/components/events/error/Frame.tsx
@@ -51,10 +51,9 @@ function FileActions({ frame }: { frame: EventFrame }) {
     return null;
   }
   const resolvedFilename = resolveFilename(frame.filename);
-  const canOpenFileInEditor = !frame.filename?.includes(':');
   return (
     <div className="flex items-center gap-2">
-      {canOpenFileInEditor && <OpenInEditor file={`${resolvedFilename}:${frame.lineno}:${frame.colno}`} />}
+      <OpenInEditor file={`${resolvedFilename}:${frame.lineno}:${frame.colno}`} />
       <CopyToClipboard data={resolvedFilename} />
     </div>
   );

--- a/packages/overlay/src/integrations/sentry/components/events/error/Frame.tsx
+++ b/packages/overlay/src/integrations/sentry/components/events/error/Frame.tsx
@@ -51,9 +51,10 @@ function FileActions({ frame }: { frame: EventFrame }) {
     return null;
   }
   const resolvedFilename = resolveFilename(frame.filename);
+  const canOpenFileInEditor = !frame.filename?.includes(':');
   return (
     <div className="flex items-center gap-2">
-      <OpenInEditor file={`${resolvedFilename}:${frame.lineno}:${frame.colno}`} />
+      {canOpenFileInEditor && <OpenInEditor file={`${resolvedFilename}:${frame.lineno}:${frame.colno}`} />}
       <CopyToClipboard data={resolvedFilename} />
     </div>
   );

--- a/packages/overlay/src/integrations/sentry/components/performance/PerformanceTabDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/performance/PerformanceTabDetails.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Outlet, Route, Routes } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import Tabs from '~/components/Tabs';
 import { useSpotlightContext } from '~/lib/useSpotlightContext';
 import { useSentrySpans } from '../../data/useSentrySpans';
@@ -58,7 +58,8 @@ export default function PerformanceTabDetails() {
           <Route path="webvitals" element={<WebVitals />} />
           <Route path="webvitals/:page" element={<WebVitalsDetail />} />
           {/* Default tab */}
-          <Route path="*" element={<Queries showAll={showAll} />} />
+          <Route path="queries" element={<Queries showAll={showAll} />} />
+          <Route path="*" element={<Navigate to="/performance/queries" replace />} />
         </Routes>
         <Outlet />
       </div>

--- a/packages/overlay/src/integrations/sentry/components/traces/spans/SpanDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/spans/SpanDetails.tsx
@@ -203,7 +203,7 @@ export default function SpanDetails({
           </div>
         )}
 
-        {span.children?.length && (
+        {(span.children?.length ?? 0) > 0 && (
           <div>
             <h2 className="mb-2 font-bold uppercase">Sub-tree</h2>
             <SpanTree


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

- Fixed condition for showing open file in editor icon on error frame - missed here https://github.com/getsentry/spotlight/pull/550
- changed route and added navigation in performance tab to make queries tab default active.
- Fixed showing of 0 in false condition in span details

