### PR TITLE
fix: Fix hanging on SIGINT termination

### DIFF
--- a/.changeset/nasty-suits-roll.md
+++ b/.changeset/nasty-suits-roll.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/sidecar': patch
+'@spotlightjs/spotlight': patch
+---
+
+Fix hang at SIGINT termination

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -427,7 +427,7 @@ export function clearBuffer(): void {
 export function shutdown() {
   if (serverInstance) {
     logger.info('Shutting down server...');
-    serverInstance.close();
+    serverInstance.closeAllConnections();
   }
 }
 


### PR DESCRIPTION
We were calling `server.close()` which only stops new requests from being accepted. It still keeps any open connections, including idle ones for keep-alive. This change forcefully terminates all these connections so the program can exit timely.
