### PR TITLE
feat: Add method name to trace list

### DIFF
--- a/.changeset/short-wombats-brush.md
+++ b/.changeset/short-wombats-brush.md
@@ -1,0 +1,8 @@
+---
+'@spotlightjs/overlay': minor
+'@spotlightjs/astro': minor
+'@spotlightjs/electron': minor
+'@spotlightjs/spotlight': minor
+---
+
+Add method name to trace list

--- a/packages/overlay/src/integrations/sentry/components/events/EventList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/events/EventList.tsx
@@ -6,14 +6,9 @@ import CardList from '../../../../components/CardList';
 import TimeSince from '../../../../components/TimeSince';
 import { useSentryEvents } from '../../data/useSentryEvents';
 import { useSentryHelpers } from '../../data/useSentryHelpers';
-import type { SentryEvent } from '../../types';
 import HiddenItemsButton from '../HiddenItemsButton';
 import PlatformIcon from '../PlatformIcon';
 import { EventSummary } from './Event';
-
-function renderEvent(event: SentryEvent) {
-  return <EventSummary event={event} />;
-}
 
 export default function EventList({ traceId }: { traceId?: string }) {
   const events = useSentryEvents(traceId);
@@ -59,7 +54,9 @@ export default function EventList({ traceId }: { traceId?: string }) {
               <span />
               <TimeSince date={e.timestamp} />
             </div>
-            <div className="flex-1">{renderEvent(e)}</div>
+            <div className="flex-1">
+              <EventSummary event={e} />
+            </div>
           </Link>
         );
       })}

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
@@ -1,30 +1,27 @@
 import { useState } from 'react';
 import type { Trace } from '../../types';
 import { Link } from 'react-router-dom';
-import Badge from '~/ui/Badge';
 import CardList from '../../../../components/CardList';
 import TimeSince from '../../../../components/TimeSince';
 import classNames from '../../../../lib/classNames';
 import { useSpotlightContext } from '../../../../lib/useSpotlightContext';
 import { useSentryHelpers } from '../../data/useSentryHelpers';
 import { useSentryTraces } from '../../data/useSentryTraces';
+import Badge from '../../../../ui/Badge';
+import Tag from '../../../../ui/Tag';
 import { getDuration } from '../../utils/duration';
 import HiddenItemsButton from '../HiddenItemsButton';
 import TraceIcon from './TraceIcon';
 
 function TransactionName({ trace }: { trace: Trace }) {
   const method = String(
-    trace.rootTransaction?.contexts?.trace.data?.method || trace.rootTransaction?.request?.method || '(GET)',
+    trace.rootTransaction?.contexts?.trace.data?.method || trace.rootTransaction?.request?.method || '',
   );
-  const name = trace.rootTransactionName.startsWith(method)
-    ? trace.rootTransactionName.slice(method.length + 1)
-    : trace.rootTransactionName;
-  return (
-    <div className="border-primary-300 bg-primary-900 divide-x-primary-300 text-smflex inline-flex divide-x whitespace-nowrap rounded-full border font-mono">
-      <div className="px-2 py-1 font-semibold">{method}</div>
-      <div className="bg-primary-800 rounded-r-full px-2 py-1">{name}</div>
-    </div>
-  );
+  const name =
+    method && trace.rootTransactionName.startsWith(method)
+      ? trace.rootTransactionName.slice(method.length + 1)
+      : trace.rootTransactionName;
+  return <Tag tagKey={method} value={name} />;
 }
 
 export default function TraceList() {

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import type { Trace } from '../../types';
 import { Link } from 'react-router-dom';
 import Badge from '~/ui/Badge';
 import CardList from '../../../../components/CardList';
@@ -10,6 +11,21 @@ import { useSentryTraces } from '../../data/useSentryTraces';
 import { getDuration } from '../../utils/duration';
 import HiddenItemsButton from '../HiddenItemsButton';
 import TraceIcon from './TraceIcon';
+
+function TransactionName({ trace }: { trace: Trace }) {
+  const method = String(
+    trace.rootTransaction?.contexts?.trace.data?.method || trace.rootTransaction?.request?.method || '(GET)',
+  );
+  const name = trace.rootTransactionName.startsWith(method)
+    ? trace.rootTransactionName.slice(method.length + 1)
+    : trace.rootTransactionName;
+  return (
+    <div className="border-primary-300 bg-primary-900 divide-x-primary-300 text-smflex inline-flex divide-x whitespace-nowrap rounded-full border font-mono">
+      <div className="px-2 py-1 font-semibold">{method}</div>
+      <div className="bg-primary-800 rounded-r-full px-2 py-1">{name}</div>
+    </div>
+  );
+}
 
 export default function TraceList() {
   const traceList = useSentryTraces();
@@ -50,8 +66,8 @@ export default function TraceList() {
                   </div>
                   <TimeSince date={trace.start_timestamp} />
                 </div>
+                <TransactionName trace={trace} />
                 <div className="flex flex-col truncate font-mono">
-                  <div>{trace.rootTransactionName}</div>
                   <div className="text-primary-300 flex space-x-2 text-sm">
                     <div
                       className={classNames(

--- a/packages/overlay/src/integrations/sentry/types.ts
+++ b/packages/overlay/src/integrations/sentry/types.ts
@@ -45,6 +45,8 @@ export type Breadcrumb = {
   type: string | 'default';
 };
 
+export type Context = Record<string, string | number>;
+
 type CommonEventAttrs = {
   // not always present, but we are forcing it in EventCache
   event_id: string;
@@ -59,15 +61,11 @@ type CommonEventAttrs = {
   start_timestamp?: number;
   contexts?: Contexts;
   tags?: Tags;
-  extra?: Record<string, string | number>;
+  extra?: Context;
   request?: Record<string, Record<string, string> | string>;
   modules?: Record<string, string>;
   sdk?: Sdk;
   measurements?: Measurements;
-};
-
-export type Context = {
-  [key: string]: string | number;
 };
 
 export type TraceContext = {
@@ -77,6 +75,7 @@ export type TraceContext = {
   op: string;
   description?: string | null;
   status: 'ok' | string;
+  data?: Context;
 };
 
 export type Contexts = {

--- a/packages/overlay/src/ui/Tag/Tag.tsx
+++ b/packages/overlay/src/ui/Tag/Tag.tsx
@@ -1,10 +1,14 @@
+import classNames from '~/lib/classNames';
+
 export type TagProps = { tagKey: string; value: string };
 
 export default function Tag({ tagKey, value }: TagProps) {
   return (
     <div className="border-primary-300 bg-primary-900 divide-x-primary-300 inline-flex divide-x whitespace-nowrap rounded-full border font-mono text-sm">
-      <div className="px-2 py-1 font-semibold">{tagKey}</div>
-      <div className="bg-primary-800 rounded-r-full px-2 py-1">{value}</div>
+      {tagKey ? <div className="px-2 py-1 font-semibold">{tagKey}</div> : null}
+      <div className={classNames('bg-primary-800', 'px-2', 'py-1', tagKey ? 'rounded-r-full' : 'rounded-full')}>
+        {value}
+      </div>
     </div>
   );
 }

--- a/packages/overlay/src/ui/Tag/Tag.tsx
+++ b/packages/overlay/src/ui/Tag/Tag.tsx
@@ -1,14 +1,10 @@
-import classNames from '~/lib/classNames';
-
 export type TagProps = { tagKey: string; value: string };
 
 export default function Tag({ tagKey, value }: TagProps) {
-  return (
-    <div className="border-primary-300 bg-primary-900 divide-x-primary-300 inline-flex divide-x whitespace-nowrap rounded-full border font-mono text-sm">
+  return value ? (
+    <div className="border-primary-300 bg-primary-900 divide-x-primary-300 inline-flex divide-x overflow-hidden whitespace-nowrap rounded-full border font-mono text-sm">
       {tagKey ? <div className="px-2 py-1 font-semibold">{tagKey}</div> : null}
-      <div className={classNames('bg-primary-800', 'px-2', 'py-1', tagKey ? 'rounded-r-full' : 'rounded-full')}>
-        {value}
-      </div>
+      <div className="bg-primary-800 rounded-full px-2 py-1">{value}</div>
     </div>
-  );
+  ) : null;
 }


### PR DESCRIPTION
Fixes #594.

With Astro where we _may_ get the method name in the description already:

![image](https://github.com/user-attachments/assets/7b6e6a33-7647-4d02-90a8-da5430fb4424)

With Django SDK where we don't get method name in transaction name:

![image](https://github.com/user-attachments/assets/f47a5e24-183b-4188-9261-5cee20c4c2e2)
