### PR TITLE
feat: Force-enable tracing with spotlight injection

### DIFF
--- a/.changeset/neat-dots-learn.md
+++ b/.changeset/neat-dots-learn.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Force-enable tracing with FE spotlight injection

--- a/demos/astro-playground/sentry.client.config.ts
+++ b/demos/astro-playground/sentry.client.config.ts
@@ -2,6 +2,4 @@ import * as Sentry from '@sentry/astro';
 
 Sentry.init({
   debug: true,
-  integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
-  tracesSampleRate: 1.0,
 });

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -241,6 +241,12 @@ function addSpotlightIntegrationToSentry(options: SentryIntegrationOptions) {
     }
   }
 
+  // HACK: Force enable transactions for this session and disable the existing DSN
+  // @ts-ignore
+  sentryClient._dsn = undefined;
+  // @ts-ignore
+  sentryClient._options.tracesSampler = () => 1;
+
   try {
     const integration = spotlightIntegration();
     sentryClient.addIntegration(integration);


### PR DESCRIPTION
This should enable us to inject Spotlight into live sites through [pure HTML injection](https://spotlightjs.com/setup/html/) for playing around. The change will force-enable tracing to 100% and disables the `DSN` to avoid spamming upstream cloud instance.