### PR TITLE
fix(spotlight): Don't upload platform binaries to npm

### DIFF
--- a/.changeset/moody-emus-smell.md
+++ b/.changeset/moody-emus-smell.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': patch
+---
+
+Don't upload platform binaries to npm :facepalm:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ env:
   BUILD_CACHE_KEY: ${{ github.sha }}
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/packages/*/dist
-    ${{ github.workspace }}/packages/*/bin
+    ${{ github.workspace }}/packages/*/dist-bin
 
 jobs:
   build:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Smoke test
         env:
-          SPOTLIGHT_BINARY: ${{ github.workspace }}/packages/spotlight/dist/spotlight-${{ runner.os }}-${{ runner.arch }}
+          SPOTLIGHT_BINARY: ${{ github.workspace }}/packages/spotlight/dist-bin/spotlight-${{ runner.os }}-${{ runner.arch }}
         run: |
           # Lowercase the binary name because `runner.os` and `runner.arch` are uppercase :facepalm:
           SPOTLIGHT_BINARY=$(echo "$SPOTLIGHT_BINARY" | tr '[:upper:]' '[:lower:]')
@@ -81,12 +81,12 @@ jobs:
             packages/spotlight/dist/spotlight.cjs
             packages/spotlight/dist/overlay/
 
-      - name: Store standalone spotlight binary
+      - name: Store standalone spotlight binaries
         uses: actions/upload-artifact@v4
         with:
           name: spotlight
           if-no-files-found: error
-          path: packages/spotlight/dist/spotlight-*
+          path: packages/spotlight/dist-bin/spotlight-*
 
       - name: Update build cache
         uses: actions/cache/save@v4
@@ -190,7 +190,7 @@ jobs:
 
       - name: Rename x64 to amd64
         # This is because Node ecosystem uses x64, but Docker uses amd64 :shrug:
-        run: mv packages/spotlight/dist/spotlight-linux-x64 packages/spotlight/dist/spotlight-linux-amd64
+        run: mv packages/spotlight/dist-bin/spotlight-linux-x64 packages/spotlight/dist-bin/spotlight-linux-amd64
 
       - name: Login to GHCR
         uses: docker/login-action@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,7 @@ env:
   BUILD_CACHE_KEY: ${{ github.event.workflow_run.head_sha || inputs.sha }}
   CACHED_BUILD_PATHS: |
     ${{ github.workspace }}/packages/*/dist
-    ${{ github.workspace }}/packages/*/bin
+    ${{ github.workspace }}/packages/*/dist-bin
 
 jobs:
   npm:
@@ -91,7 +91,7 @@ jobs:
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           file_glob: true
-          file: packages/spotlight/dist/spotlight-*
+          file: packages/spotlight/dist-bin/spotlight-*
           tag: ${{ steps.latest_release_info.outputs.tag_name }}
           make_latest: false
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 out
 dist
+dist-bin
 node
 dist-ssr
 *.local

--- a/packages/spotlight/bin/build.js
+++ b/packages/spotlight/bin/build.js
@@ -14,7 +14,7 @@ import { inject } from 'postject';
 
 const execFile = promisify(execFileCb);
 
-const DIST_DIR = './dist';
+const DIST_DIR = './dist-bin';
 const ASSETS_DIR = join(DIST_DIR, 'overlay');
 const MANIFEST_NAME = 'manifest.json';
 const MANIFEST_PATH = join(ASSETS_DIR, MANIFEST_NAME);


### PR DESCRIPTION
We blew the npm package size to 0.5GB since we placed the binaries under `/dist` which gets uploaded to npm! This patch moves them to `/dist-bin` to avoid the issue.
