### PR TITLE
fix(sentry-integration): Make direct SDK link more graceful at the start

### DIFF
--- a/.changeset/thick-berries-taste.md
+++ b/.changeset/thick-berries-taste.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/overlay': patch
+'@spotlightjs/spotlight': patch
+---
+
+Make in-browser direct Sentry SDK link more graceful at the start

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -26,7 +26,7 @@ export default function sentryIntegration(options: SentryIntegrationOptions = {}
 
     setup: ({ open, sidecarUrl }) => {
       if (options.retries == null) {
-        options.retries = 3;
+        options.retries = 10;
       }
       if (sidecarUrl) {
         sentryDataCache.setSidecarUrl(removeURLSuffix(sidecarUrl, '/stream'));
@@ -213,7 +213,7 @@ function addSpotlightIntegrationToSentry(options: SentryIntegrationOptions) {
       options.retries--;
       setTimeout(() => {
         addSpotlightIntegrationToSentry(options);
-      }, 100);
+      }, 500);
     }
     return;
   }


### PR DESCRIPTION
When testing Spotlight with Sentry's own front-end, I noticed it quite too early and failed to hook into the JS SDK. This patch makes it a bit more graceful with longer delays and up to 10 retries.
