### PR TITLE
fix(overlay): Do not modify body styles on injection

### DIFF
--- a/.changeset/popular-kings-wave.md
+++ b/.changeset/popular-kings-wave.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/overlay': patch
+'@spotlightjs/spotlight': patch
+---
+
+Don't alter body styles at all

--- a/packages/overlay/src/App.tsx
+++ b/packages/overlay/src/App.tsx
@@ -9,6 +9,7 @@ import { log } from './lib/logger';
 import useKeyPress from './lib/useKeyPress';
 import { connectToSidecar } from './sidecar';
 import type { NotificationCount, SpotlightOverlayOptions } from './types';
+import { SPOTLIGHT_OPEN_CLASS_NAME } from './constants';
 
 type AppProps = Omit<SpotlightOverlayOptions, 'debug' | 'injectImmediately'> &
   Required<Pick<SpotlightOverlayOptions, 'sidecarUrl'>>;
@@ -217,10 +218,10 @@ export default function App({
   useEffect(() => {
     if (!isOpen) {
       spotlightEventTarget.dispatchEvent(new CustomEvent('closed'));
-      document.body.style.overflow = 'auto';
+      document.body.classList.remove(SPOTLIGHT_OPEN_CLASS_NAME);
     } else {
       spotlightEventTarget.dispatchEvent(new CustomEvent('opened'));
-      document.body.style.overflow = 'hidden';
+      document.body.classList.add(SPOTLIGHT_OPEN_CLASS_NAME);
     }
   }, [isOpen, spotlightEventTarget]);
 

--- a/packages/overlay/src/constants.ts
+++ b/packages/overlay/src/constants.ts
@@ -6,3 +6,4 @@ export const DEFAULT_EXPERIMENTS = {
 };
 
 export const DEFAULT_ANCHOR = 'bottomRight';
+export const SPOTLIGHT_OPEN_CLASS_NAME = '__spotlight_open';

--- a/packages/overlay/src/index.tsx
+++ b/packages/overlay/src/index.tsx
@@ -3,7 +3,12 @@ import { CONTEXT_LINES_ENDPOINT } from '@spotlightjs/sidecar/constants';
 import { MemoryRouter } from 'react-router-dom';
 import colors from 'tailwindcss/colors';
 import App from './App';
-import { DEFAULT_ANCHOR, DEFAULT_EXPERIMENTS, DEFAULT_SIDECAR_STREAM_URL } from './constants';
+import {
+  DEFAULT_ANCHOR,
+  DEFAULT_EXPERIMENTS,
+  DEFAULT_SIDECAR_STREAM_URL,
+  SPOTLIGHT_OPEN_CLASS_NAME,
+} from './constants';
 import globalStyles from './index.css?inline';
 import { initIntegrations, type SpotlightContext } from './integrations/integration';
 import { default as sentry } from './integrations/sentry/index';
@@ -205,6 +210,12 @@ export async function init(options: SpotlightOverlayOptions = {}) {
       return;
     }
     log('Injecting into application');
+
+    const extraSheet = new CSSStyleSheet();
+    extraSheet.replaceSync(`body.${SPOTLIGHT_OPEN_CLASS_NAME} { overflow: hidden!important; }`);
+    // Combine the existing sheets and new one
+    document.adoptedStyleSheets = [...document.adoptedStyleSheets, extraSheet];
+
     document.body.append(docRoot);
   }
 


### PR DESCRIPTION
Fixes #613.

We used to add `overflow: auto` on injection, no matter what. This is bad for a few reasons:

1. Our default is already the closed state, so we should not do anything on initial injection
2. We don't store or know the original value of this style we are touching, which may cause breakage
3. It causes hydration issues as highlighted in #613

This PR injects a special class into the DOM using [adoptedStyleSheets API](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) on injection and just toggles this class on open/close.
