### PR TITLE
fix(spotlight): Fix UI not working with different port

### DIFF
--- a/.changeset/large-flies-hunt.md
+++ b/.changeset/large-flies-hunt.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': patch
+---
+
+Fix Spotlight UI not using correct sidecar URL w/ non-default port

--- a/packages/spotlight/src/index.html
+++ b/packages/spotlight/src/index.html
@@ -20,7 +20,7 @@
   <body>
     <script type="module">
       import * as Spotlight from '@spotlightjs/overlay';
-      Spotlight.init();
+      Spotlight.init({ sidecarUrl: document.location.href });
     </script>
   </body>
 </html>


### PR DESCRIPTION
We were using the default sidecar URL even when Spotlight was started with a different port causing the UI to misbehave and also not connect to the sidecar we just started on the different port. This patch fixes the issue.
