### PR TITLE
fix(spotlight): Fix UI not working with different port take 2

### DIFF
--- a/.changeset/lemon-gorillas-beg.md
+++ b/.changeset/lemon-gorillas-beg.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/spotlight': patch
+'@spotlightjs/sidecar': patch
+---
+
+Better custom sidecar port detection in main Spotlight module

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -337,7 +337,11 @@ function startServer(
         const traceData = getTraceData();
         res.appendHeader(
           'server-timing',
-          `sentryTrace;desc="${traceData['sentry-trace']}", baggage;desc="${traceData.baggage}"`,
+          [
+            `sentryTrace;desc="${traceData['sentry-trace']}"`,
+            `baggage;desc="${traceData.baggage}"`,
+            `sentrySpotlightPort;desc=${port}`,
+          ].join(', '),
         );
         const result = route[1](req, res, pathname, searchParams);
         span.setAttribute('http.response.status_code', res.statusCode);

--- a/packages/spotlight/src/index.html
+++ b/packages/spotlight/src/index.html
@@ -20,7 +20,28 @@
   <body>
     <script type="module">
       import * as Spotlight from '@spotlightjs/overlay';
-      Spotlight.init({ sidecarUrl: document.location.href });
+      if (!window.__spotlight) {
+        window.__spotlight = {};
+      }
+      if (!window.__spotlight.initOptions) {
+        window.__spotlight.initOptions = {};
+      }
+      // This check is so that we don't override potentially SDK-injected config
+      if (!window.__spotlight.initOptions.sidecarUrl) {
+        const navTiming = performance.getEntriesByType('navigation');
+        if (navTiming.length > 0) {
+          const serverTiming = navTiming[0].serverTiming;
+          if (serverTiming && serverTiming.length > 0) {
+            for (const { name, description } of serverTiming) {
+              if (name === 'sentrySpotlightPort') {
+                window.__spotlight.initOptions.sidecarUrl = `http://localhost:${description}`;
+                break;
+              }
+            }
+          }
+        }
+      }
+      Spotlight.init();
     </script>
   </body>
 </html>


### PR DESCRIPTION
With the previous patch, we assumed the page loads `assets/main.js` is _the_ Spotlight main page which is not the case for auto injection by SDKs (only Django for now but this should expand). This patch fixes the issue by injecting `sentrySpotlightPort` in server-timing headers (yes, hack!)to avoid dynamic HTML generation from sidecar side. I tested that it works and now that it works, we may use this from Django too!
