### PR TITLE
fix: Fix electron version names in Sentry

### DIFF
--- a/packages/electron/electron.vite.config.js
+++ b/packages/electron/electron.vite.config.js
@@ -13,6 +13,10 @@ export default defineConfig(({ mode }) => {
     env = loadEnv(mode);
   }
   return {
+    define: {
+      'process.env.NODE_ENV': '"production"',
+      'process.env.npm_package_version': JSON.stringify(process.env.npm_package_version),
+    },
     main: {
       plugins: [
         sentryVitePlugin({
@@ -20,7 +24,7 @@ export default defineConfig(({ mode }) => {
           project: env.MAIN_VITE_SENTRY_PROJECT,
           authToken: env.MAIN_VITE_SENTRY_AUTH_TOKEN,
           release: {
-            name: `spotlight@${process.env.npm_package_version}`,
+            name: process.env.npm_package_version,
           },
         }),
       ],
@@ -41,7 +45,7 @@ export default defineConfig(({ mode }) => {
           project: env.MAIN_VITE_SENTRY_PROJECT,
           authToken: env.MAIN_VITE_SENTRY_AUTH_TOKEN,
           release: {
-            name: `spotlight@${process.env.npm_package_version}`,
+            name: process.env.npm_package_version,
           },
         }),
       ],

--- a/packages/electron/src/electron/main/index.ts
+++ b/packages/electron/src/electron/main/index.ts
@@ -9,7 +9,8 @@ const store = new Store();
 Sentry.init({
   dsn: 'https://192df1a78878de014eb416a99ff70269@o1.ingest.sentry.io/4506400311934976',
   tracesSampleRate: 1.0,
-  release: `spotlight@${process.env.npm_package_version}`,
+  environment: process.env.NODE_ENV,
+  release: process.env.npm_package_version,
   beforeSend: askForPermissionToSendToSentry,
 });
 

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -3,6 +3,8 @@ import * as Spotlight from '@spotlightjs/overlay';
 
 Sentry.init({
   dsn: 'https://192df1a78878de014eb416a99ff70269@o1.ingest.sentry.io/4506400311934976',
+  environment: process.env.NODE_ENV,
+  release: process.env.npm_package_version,
   integrations: [
     Sentry.browserTracingIntegration(),
     Sentry.replayIntegration({

--- a/packages/spotlight/vite.overlay.config.ts
+++ b/packages/spotlight/vite.overlay.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   define: {
-    'process.env.NODE_ENV': "'production'",
+    'process.env.NODE_ENV': '"production"',
     'process.env.npm_package_version': JSON.stringify(process.env.npm_package_version),
   },
   build: {


### PR DESCRIPTION
Currently, we see git SHAs as version names in Sentry for the Electron project. This fix should give us semver versions instead.
