### PR TITLE
fix(sidecar): Fix is sidecar running check timeouts

### DIFF
--- a/.changeset/metal-lies-brush.md
+++ b/.changeset/metal-lies-brush.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/sidecar': patch
+'@spotlightjs/spotlight': patch
+---
+
+Fix timeout mechanism on is sidecar running check


### PR DESCRIPTION
The `timeout` field we were using is only for socket timeout, causing hanging when there's an unresponsive server running on the same port. This PR fixes that along with the retry logic and its interaction with SIGINT signalling.

Fixes #627.
