### PR TITLE
typo: fix mistyped 'open'

### DIFF
--- a/packages/website/src/content/docs/reference/configuration.md
+++ b/packages/website/src/content/docs/reference/configuration.md
@@ -115,7 +115,7 @@ only the button is visible.
 
 ```ts
 init({
-  opneOnInit: true,
+  openOnInit: true,
 });
 ```
 


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

This PR fixes a mistyped "open" in spotlight configuration docs page.