### PR TITLE
fix(spotlight): Remove Windows home directories from Sentry reports

### DIFF
--- a/.changeset/thick-lizards-battle.md
+++ b/.changeset/thick-lizards-battle.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/spotlight': patch
+---
+
+Remove Windows home directories from Sentry reports

--- a/packages/spotlight/bin/instrument.js
+++ b/packages/spotlight/bin/instrument.js
@@ -28,7 +28,8 @@ init({
           continue;
         }
 
-        frame.filename = frame.filename?.replace(process.env.HOME, '~');
+        const homeDir = process.env.HOME || process.env.USERPROFILE;
+        frame.filename = frame.filename?.replace(homeDir, '~');
       }
     }
 

--- a/packages/spotlight/bin/run.js
+++ b/packages/spotlight/bin/run.js
@@ -17,10 +17,11 @@ try {
   sea = { isSea: () => false };
 }
 
+const homeDir = process.env.HOME || process.env.USERPROFILE;
 setContext('CLI', {
   sea: sea.isSea(),
   // TODO: Be less naive with path obscuring
-  argv: process.argv.map(arg => arg.replace(process.env.HOME, '~')),
+  argv: process.argv.map(arg => arg.replace(homeDir, '~')),
 });
 
 const withTracing =


### PR DESCRIPTION
Fixes #639
