### PR TITLE
ci: Fix Docker Image step fail on forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,9 +211,9 @@ jobs:
           context: .
           cache-from: type=gha,scope=prod
           cache-to: type=gha,mode=max,scope=prod
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'linux/amd64,linux/arm64' || format('linux/{0}', runner.arch) }}
           push: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
-          load: true
+          load: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'false' || 'true' }}
           tags: ghcr.io/getsentry/spotlight:${{ github.sha }}
 
       - name: Test Docker Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
           cache-from: type=gha,scope=prod
           cache-to: type=gha,mode=max,scope=prod
           platforms: linux/amd64,linux/arm64
-          push: true
+          push: ${{ github.repository_owner == 'getsentry' && 'true' || 'false' }}
           tags: ghcr.io/getsentry/spotlight:${{ github.sha }}
 
       - name: Test Docker Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,6 +213,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=prod
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
+          load: true
           tags: ghcr.io/getsentry/spotlight:${{ github.sha }}
 
       - name: Test Docker Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
           cache-from: type=gha,scope=prod
           cache-to: type=gha,mode=max,scope=prod
           platforms: linux/amd64,linux/arm64
-          push: ${{ github.repository_owner == 'getsentry' && 'true' || 'false' }}
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
           tags: ghcr.io/getsentry/spotlight:${{ github.sha }}
 
       - name: Test Docker Image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -211,7 +211,7 @@ jobs:
           context: .
           cache-from: type=gha,scope=prod
           cache-to: type=gha,mode=max,scope=prod
-          platforms: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'linux/amd64,linux/arm64' || format('linux/{0}', runner.arch) }}
+          platforms: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           push: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'true' || 'false' }}
           load: ${{ github.event.pull_request.head.repo.full_name == github.repository && 'false' || 'true' }}
           tags: ghcr.io/getsentry/spotlight:${{ github.sha }}


### PR DESCRIPTION
We cannot (and don't need to) push to GHCR from forks.
