### PR TITLE
fix: Don't crash when `score.total` is missing

### DIFF
--- a/.changeset/rude-tomatoes-brush.md
+++ b/.changeset/rude-tomatoes-brush.md
@@ -1,0 +1,8 @@
+---
+'@spotlightjs/spotlight': patch
+'@spotlightjs/electron': patch
+'@spotlightjs/overlay': patch
+'@spotlightjs/astro': patch
+---
+
+Fix rare error when `score.total` is missing from `measurements`

--- a/packages/overlay/src/integrations/sentry/utils/webVitals.ts
+++ b/packages/overlay/src/integrations/sentry/utils/webVitals.ts
@@ -1,5 +1,5 @@
-import { SentryEvent } from '~/integrations/sentry/types';
-import { WebVitals } from '../constants';
+import type { SentryEvent } from '~/integrations/sentry/types';
+import type { WebVitals } from '../constants';
 
 const SQRT_2 = Math.sqrt(2);
 
@@ -155,7 +155,7 @@ export function normalizePerformanceScore(
         };
       }
 
-      if (shouldAddTotal) {
+      if (shouldAddTotal && !Object.prototype.hasOwnProperty.call(measurements, 'score.total')) {
         measurements['score.total'] = {
           value: scoreTotal,
           unit: 'ratio',


### PR DESCRIPTION
Fixes #681.
