### PR TITLE
fix(overlay): Process profiles without thread_metadata correctly

### DIFF
--- a/.changeset/young-moons-cough.md
+++ b/.changeset/young-moons-cough.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Process profiles without thread metadata correctly

--- a/packages/overlay/src/integrations/sentry/data/profiles.ts
+++ b/packages/overlay/src/integrations/sentry/data/profiles.ts
@@ -103,7 +103,7 @@ export function getSpansFromProfile(
       tags: { source: 'profile' },
       data: {
         'thread.id': sample.thread_id,
-        'thread.name': profile.thread_metadata[sample.thread_id as keyof typeof profile.thread_metadata]?.name,
+        'thread.name': profile.thread_metadata?.[sample.thread_id as keyof typeof profile.thread_metadata]?.name,
       },
     };
     const sampleSpan: Span = {
@@ -112,7 +112,7 @@ export function getSpansFromProfile(
       ...commonAttributes,
       op: 'Thread',
       description:
-        profile.thread_metadata[sample.thread_id as keyof typeof profile.thread_metadata]?.name ||
+        profile.thread_metadata?.[sample.thread_id as keyof typeof profile.thread_metadata]?.name ||
         `Thread ${sample.thread_id}`,
       data: {
         thread_id: sample.thread_id,

--- a/packages/overlay/src/integrations/sentry/types.ts
+++ b/packages/overlay/src/integrations/sentry/types.ts
@@ -143,7 +143,7 @@ export type SentryProfile = {
   stacks: number[][];
   frames: EventFrame[];
   platform?: string;
-  thread_metadata: Record<
+  thread_metadata?: Record<
     string,
     {
       name?: string;


### PR DESCRIPTION
Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

Per https://github.com/getsentry/sentry/blob/55d233c4ac771a876b1dc17a0a0dd330bc7179c8/static/app/types/profiling.d.ts#L119 the `thread_metadata` property is optional, and locally Spotlight now crashes because it's missing for the PHP integration.
