### PR TITLE
Move download actions into relevant docs

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -122,6 +122,10 @@ export default defineConfig({
               link: '/setup/html/',
             },
             {
+              label: 'For Headless Environments',
+              link: '/setup/headless/',
+            },
+            {
               label: 'For Other Frameworks',
               link: '/setup/other/',
             },

--- a/packages/website/src/components/Hero.astro
+++ b/packages/website/src/components/Hero.astro
@@ -1,7 +1,6 @@
 ---
 import { Fragment } from 'react';
 import ButtonLink from './ButtonLink.astro';
-import DownloadButton from './DownloadButton.astro';
 
 // Used to override the default hero component
 ---
@@ -86,8 +85,6 @@ import DownloadButton from './DownloadButton.astro';
   <div class="sub-heading mb-4">Spotlight is a highly customizable debug tool embedded in your web app.</div>
   <div class="flex flex-col items-center justify-center gap-2 py-4 mb-4">
     <ButtonLink href="/about/">Get Started</ButtonLink>
-    <div class="text-xs uppercase">or download for</div>
-    <DownloadButton>Download for Mac</DownloadButton>
   </div>
   <img src="/images/trace.png" alt="Spotlight Hero" class="hero-image" />
 </div>

--- a/packages/website/src/content/docs/about.mdx
+++ b/packages/website/src/content/docs/about.mdx
@@ -6,6 +6,7 @@ sidebar:
   label: What is Spotlight?
   order: 0
 ---
+import DownloadButton from '../../components/DownloadButton.astro';
 
 Spotlight started out as a [Hackweek project](https://syntax.fm/show/666/hackweek-projects-realtime-markdown-editor-and-a-hardware-recording-button) at Sentry:
 
@@ -49,5 +50,8 @@ npx @spotlightjs/spotlight
 The overlay itself behaves a little differently from Sentry. That's intentional both because this is for local
 development, but also because the project is completely independent of Sentry (other than our guaranteed support).
 
-Spotlight can show you errors, traces, configurations settings, installed dependencies, you name it. Spotlight is developed with customizablity in mind, so you can add your own integrations to it.
+Alternatively, we provide an Electron-based application that can be used to run the Sidecar as well as a dedicated instance of the overlay. There are some limitations to this method, but it is particularly useful [for headless or mobile environments](/setup/headless/).
 
+<DownloadButton>Download for Mac</DownloadButton>
+
+Spotlight can show you errors, traces, configurations settings, installed dependencies, you name it. Spotlight is developed with customizablity in mind, so you can add your own integrations to it.

--- a/packages/website/src/content/docs/setup/headless.mdx
+++ b/packages/website/src/content/docs/setup/headless.mdx
@@ -1,0 +1,29 @@
+---
+title: Using Spotlight's Electron App
+description: Use the overlay in a headless environment
+---
+import DownloadButton from '../../../components/DownloadButton.astro';
+
+Spotlight provides an Electron app that can be used to run the Sidecar as well as a dedicated instance of the overlay.
+
+This is most useful for headless environments (like an API service), but is also critical for non-web client applications, such as mobile and desktop apps.
+
+## Installation
+
+Get started by downloading the latest version of the Electron app for your platform.
+
+<DownloadButton>Download for Mac</DownloadButton>
+
+## Usage
+
+In addition to loading the application, make sure you've enabled spotlight in the relevant Sentry SDKs (e.g. via `spotlight: true`):
+
+```javascript
+import * as Sentry from '@sentry/browser';
+
+Sentry.init({
+  dsn: '___DSN___',
+  spotlight: process.env.NODE_ENV === 'development'
+  // ...other Sentry options
+});
+```


### PR DESCRIPTION
Its not overly useful to suggest folks download the app when there are additional steps to get Spotlight working.

- Add download actions and a bit of explainer to the about page.
- Add new headless environments setup guide.
