### PR TITLE
fix: Null-check sentryClient._options

### DIFF
--- a/.changeset/neat-zoos-kiss.md
+++ b/.changeset/neat-zoos-kiss.md
@@ -1,0 +1,8 @@
+---
+'@spotlightjs/spotlight': patch
+'@spotlightjs/electron': patch
+'@spotlightjs/overlay': patch
+'@spotlightjs/astro': patch
+---
+
+fix: Null-check sentryClient.\_options

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -239,9 +239,15 @@ function addSpotlightIntegrationToSentry(options: SentryIntegrationOptions, side
   // @ts-ignore
   sentryClient._dsn = undefined;
   // @ts-ignore
+  if (!sentryClient._options) {
+    // @ts-ignore
+    sentryClient._options = {};
+  }
+  // @ts-ignore
   sentryClient._options.tracesSampler = () => 1;
   // @ts-ignore
   sentryClient._options.sampleRate = 1;
+  // TODO:  Enable profiling and set sample rate to 1 for that too
 
   try {
     // @ts-expect-error ts(2339) -- We're accessing a private property here


### PR DESCRIPTION
We got a report of an error when we tried to set `sentryClient._options.tracesSampler` implying that `sentryClient._options` might be `null` or `undefined`. This patch adds protection around that.
