### PR TITLE
feat: Keep profile spans collapsed

### DIFF
--- a/.changeset/big-cheetahs-change.md
+++ b/.changeset/big-cheetahs-change.md
@@ -1,0 +1,8 @@
+---
+'@spotlightjs/spotlight': minor
+'@spotlightjs/electron': minor
+'@spotlightjs/overlay': minor
+'@spotlightjs/astro': minor
+---
+
+feat: Keep profile spans collapsed

--- a/packages/overlay/src/integrations/sentry/components/explore/traces/spans/SpanItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/explore/traces/spans/SpanItem.tsx
@@ -33,7 +33,11 @@ const SpanItem = ({
   const containerRef = useRef<HTMLLIElement>(null);
   const childrenCount = span.children ? span.children.length : 0;
   const [isItemCollapsed, setIsItemCollapsed] = useState(
-    ((span.transaction && totalTransactions > 1) || depth >= 10 || childrenCount > 10) && depth !== 1,
+    ((span.transaction && totalTransactions > 1) ||
+      depth >= 10 ||
+      childrenCount > 10 ||
+      span.tags?.source === 'profile') &&
+      depth !== 1,
   );
   const [isResizing, setIsResizing] = useState(false);
 


### PR DESCRIPTION
This helps with crazy rendering times with deep profile trees
