### PR TITLE
fix: node filename format was wrong

### DIFF
--- a/.changeset/serious-donkeys-try.md
+++ b/.changeset/serious-donkeys-try.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': major
+---
+
+format node internals correctly in stacktrace

--- a/.changeset/serious-donkeys-try.md
+++ b/.changeset/serious-donkeys-try.md
@@ -1,5 +1,5 @@
 ---
-'@spotlightjs/overlay': major
+'@spotlightjs/overlay': patch
 ---
 
 format node internals correctly in stacktrace

--- a/packages/overlay/src/integrations/sentry/components/events/error/Frame.tsx
+++ b/packages/overlay/src/integrations/sentry/components/events/error/Frame.tsx
@@ -17,6 +17,7 @@ function resolveFilename(filename: string) {
 }
 
 function formatFilename(filename: string) {
+  if (filename.startsWith('node:')) return filename;
   const resolvedFilename = resolveFilename(filename);
   if (resolvedFilename.indexOf('/node_modules/') === -1) return resolvedFilename;
   return `npm:${resolvedFilename


### PR DESCRIPTION
Very minor quirk noticed with the stacktrace... node internals were being formatted incorrectly by `formatFilename`, so this change just returns them as is, since they are formatted well to begin with.

before: 

![image](https://github.com/user-attachments/assets/163c0149-26df-4a4d-8799-9978fc8d2da8)

after: 

![image](https://github.com/user-attachments/assets/ee782cde-ac4e-474c-ba46-fb356977460a)
