### PR TITLE
feat: filter spans on search

### DIFF
--- a/.changeset/sweet-poets-reflect.md
+++ b/.changeset/sweet-poets-reflect.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Include filter functionality when searching spans

--- a/packages/overlay/src/integrations/sentry/components/explore/traces/spans/SpanItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/explore/traces/spans/SpanItem.tsx
@@ -1,7 +1,6 @@
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { ReactComponent as ChevronIcon } from '~/assets/chevronDown.svg';
-import { useSearch } from '~/integrations/sentry/context/SearchContext';
 import classNames from '../../../../../../lib/classNames';
 import type { Span, TraceContext } from '../../../../types';
 import { getFormattedDuration, getSpanDurationClassName } from '../../../../utils/duration';
@@ -29,7 +28,6 @@ const SpanItem = ({
   setSpanNodeWidth?: (val: number) => void;
 }) => {
   const { spanId } = useParams();
-  const { query } = useSearch();
   const containerRef = useRef<HTMLLIElement>(null);
   const childrenCount = span.children ? span.children.length : 0;
   const [isItemCollapsed, setIsItemCollapsed] = useState(
@@ -51,17 +49,12 @@ const SpanItem = ({
       setSpanNodeWidth(newLeftWidth);
     }
   };
-  const isQueried = useMemo(() => {
-    if (!query) return false;
-    return span.span_id.includes(query) || span.op?.includes(query) || span.description?.includes(query);
-  }, [query, span.span_id, span.op, span.description]);
 
   return (
     <li key={span.span_id} ref={containerRef}>
       <Link
         className={classNames(
           'hover:bg-primary-700 group flex rounded-sm text-sm',
-          isQueried ? 'bg-primary-200 bg-opacity-20' : '',
           spanId === span.span_id ? 'bg-primary-900' : '',
           span.tags?.source === 'profile' ? 'text-lime-500' : '',
         )}
@@ -73,7 +66,6 @@ const SpanItem = ({
         <div
           className={classNames(
             'node group-hover:bg-primary-700 rounded-sm',
-            isQueried ? 'bg-transparent' : '',
             span.status && span.status !== 'ok' ? 'text-red-400' : '',
             spanId === span.span_id ? 'bg-primary-900' : 'bg-primary-950',
           )}
@@ -109,7 +101,7 @@ const SpanItem = ({
           </span>
         </div>
         <div
-          className={classNames('waterfall group-hover:bg-primary-700 rounded-sm', isQueried ? '!bg-transparent' : '')}
+          className={classNames('waterfall group-hover:bg-primary-700 rounded-sm')}
           style={{
             left: `${spanNodeWidth}%`,
           }}


### PR DESCRIPTION
Related to #731 
>We should have an actual filtering functionality, not just highlight

These changes add filtering to span search
- uplifted search functionality from `SpanItem` to `SpanTree`.
- Implemented DFS to handle nested search.
- Also removed highlighting from matching spans.

The results display not only the direct matches but also their hierarchical context up to the root: 

<img width="1422" alt="Screenshot 2025-03-24 at 22 24 09" src="https://github.com/user-attachments/assets/cdbccb82-64d0-4572-a2cb-238042681994" />
<img width="1428" alt="Screenshot 2025-03-24 at 22 24 31" src="https://github.com/user-attachments/assets/beed8e93-3c46-4375-8094-6c885c4a8794" />
<img width="1425" alt="Screenshot 2025-03-24 at 22 23 58" src="https://github.com/user-attachments/assets/824fec08-5c2c-4d7b-be79-495df05dea79" />

Since spans are time-sorted, it would be useful to add a feature like `+<#items>` between results. This would allow you to jump directly to the result you’re looking for when debugging. I’ve been using Spotlight for the past few days, and this addition would have been very helpful.

![Screenshot 2025-03-24 at 22 30 05](https://github.com/user-attachments/assets/ee09176f-af2c-447f-a346-b99b63d72b3c)


Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses
