### PR TITLE
docs: add "export" to VOLTA_FEATURE_PNPM

### DIFF
--- a/packages/website/src/content/docs/contribute/index.mdx
+++ b/packages/website/src/content/docs/contribute/index.mdx
@@ -17,7 +17,7 @@ Make sure you [enable `pnpm` support for `Volta`](https://docs.volta.sh/advanced
 
 ```shell
 # Add this to your profile file or startup script
-VOLTA_FEATURE_PNPM=1
+export VOLTA_FEATURE_PNPM=1
 ```
 
 :::


### PR DESCRIPTION
From [contribute docs](https://spotlightjs.com/contribute/):

```bash
# Add this to your profile file or startup script
VOLTA_FEATURE_PNPM=1
```

This is technically incomplete, so adding `export` makes it a bit more straightforward (just copy/paste from the docs).

Before opening this PR:

- [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses
