### PR TITLE
Fix: Parsing of envelope data

### DIFF
--- a/.changeset/eight-crews-explain.md
+++ b/.changeset/eight-crews-explain.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fixed parsing of envelope data.

--- a/packages/overlay/src/integrations/sentry/components/explore/envelopes/EnvelopeDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/explore/envelopes/EnvelopeDetails.tsx
@@ -1,14 +1,22 @@
 import type { Envelope } from '@sentry/core';
 import { useState } from 'react';
 import type { RawEventContext } from '~/integrations/integration';
+import { parseStringFromBuffer } from '~/integrations/sentry/utils/bufferParsers';
 import SidePanel, { SidePanelHeader } from '~/ui/SidePanel';
 import JsonViewer from '../../../../../components/JsonViewer';
 
 export default function EnvelopeDetails({ data }: { data: { envelope: Envelope; rawEnvelope: RawEventContext } }) {
   const [showRawJSON, setShowRawJSON] = useState<boolean>(false);
   const { envelope, rawEnvelope } = data;
+
   const header = envelope[0];
   const items = envelope[1];
+
+  const rawEnvelopeData = {
+    ...rawEnvelope,
+    data: typeof rawEnvelope.data === 'string' ? rawEnvelope.data : parseStringFromBuffer(rawEnvelope.data),
+  };
+
   const downloadUrl = URL.createObjectURL(new Blob([rawEnvelope.data], { type: rawEnvelope.contentType }));
   const downloadName = `${header.event_id}-${rawEnvelope.contentType}.bin`;
   return (
@@ -42,7 +50,7 @@ export default function EnvelopeDetails({ data }: { data: { envelope: Envelope; 
 
       {showRawJSON ? (
         <div className="flex-1 overflow-y-auto">
-          <JsonViewer data={rawEnvelope} />
+          <JsonViewer data={rawEnvelopeData} />
         </div>
       ) : (
         <div className="flex flex-col gap-6 space-y-6">

--- a/packages/overlay/src/integrations/sentry/index.ts
+++ b/packages/overlay/src/integrations/sentry/index.ts
@@ -12,6 +12,7 @@ import PerformanceTab from './tabs/PerformanceTab';
 import type { SentryErrorEvent, SentryEvent } from './types';
 
 import { spotlightBrowserIntegration } from '@sentry/browser';
+import { parseJSONFromBuffer } from './utils/bufferParsers';
 
 const HEADER = 'application/x-sentry-envelope';
 
@@ -110,10 +111,6 @@ function getLineEnd(data: Uint8Array): number {
   }
 
   return end;
-}
-
-function parseJSONFromBuffer(data: Uint8Array): object {
-  return JSON.parse(new TextDecoder().decode(data));
 }
 
 /**

--- a/packages/overlay/src/integrations/sentry/utils/bufferParsers.ts
+++ b/packages/overlay/src/integrations/sentry/utils/bufferParsers.ts
@@ -1,0 +1,19 @@
+import { log } from '~/lib/logger';
+
+export function parseJSONFromBuffer<T = unknown>(data: Uint8Array): T | null {
+  try {
+    return JSON.parse(new TextDecoder().decode(data)) as T;
+  } catch (err) {
+    log(err);
+    return null;
+  }
+}
+
+export function parseStringFromBuffer(data: Uint8Array): string | null {
+  try {
+    return new TextDecoder().decode(data);
+  } catch (err) {
+    log(err);
+    return null;
+  }
+}

--- a/packages/overlay/src/integrations/sentry/utils/bufferParsers.ts
+++ b/packages/overlay/src/integrations/sentry/utils/bufferParsers.ts
@@ -1,11 +1,11 @@
 import { log } from '~/lib/logger';
 
-export function parseJSONFromBuffer<T = unknown>(data: Uint8Array): T | null {
+export function parseJSONFromBuffer<T = unknown>(data: Uint8Array): T {
   try {
     return JSON.parse(new TextDecoder().decode(data)) as T;
   } catch (err) {
     log(err);
-    return null;
+    return {} as T;
   }
 }
 


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

We should parse the envelope data to string while showing raw envelope data.

Earlier
![image](https://github.com/user-attachments/assets/972565fc-fde1-40df-928d-56b2748bfb03)

Now
![image](https://github.com/user-attachments/assets/cd4ad147-8740-4503-8f7e-5b75c94c0451)

