### PR TITLE
ref(overlay): Switch Errors and Explore tab places

### DIFF
--- a/.changeset/eight-rats-sing.md
+++ b/.changeset/eight-rats-sing.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/overlay': minor
+---
+
+Swap "Errors" and "Explore" tab places, making "Explore" the default. It makes more sense this way as there is almost
+guaranteed to have traces in a good setup but not really errors.

--- a/packages/overlay/src/integrations/sentry/components/explore/index.tsx
+++ b/packages/overlay/src/integrations/sentry/components/explore/index.tsx
@@ -1,23 +1,12 @@
 import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import Tabs from '~/components/Tabs';
-import sentryDataCache from '../../data/sentryDataCache';
 import { createTab } from '../../utils/tabs';
 import EnvelopesTab from './envelopes';
 import SdksTab from './sdks';
 import TracesTab from './traces';
 
 export default function ExploreTabDetails() {
-  const localTraces = sentryDataCache.getTraces().filter(t => sentryDataCache.isTraceLocal(t.trace_id) !== false);
-
-  const tabs = [
-    createTab('traces', 'Traces', {
-      notificationCount: {
-        count: localTraces.length,
-      },
-    }),
-    createTab('sdks', 'SDKs'),
-    createTab('envelopes', 'Envelopes'),
-  ];
+  const tabs = [createTab('traces', 'Traces'), createTab('sdks', 'SDKs'), createTab('envelopes', 'Envelopes')];
 
   return (
     <>


### PR DESCRIPTION
Explore tab is way more useful than errors tab as the default so switch places.
