### PR TITLE
fix(overlay): Fix eager profile grafting on incomplete trace data

### DIFF
--- a/.changeset/warm-fans-beam.md
+++ b/.changeset/warm-fans-beam.md
@@ -1,0 +1,7 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+Fixes a race condition where we try to graft a trace which was a skeleton generated from a trace context rather than a
+full trace. This was causing profile frames not getting grafted as the start_timestamp and timestamp values were not set
+correctly.

--- a/packages/overlay/src/integrations/sentry/data/profiles.ts
+++ b/packages/overlay/src/integrations/sentry/data/profiles.ts
@@ -163,6 +163,7 @@ export function graftProfileSpans(
   parent: Span | Trace = trace,
   profile?: SentryProfileWithTraceMeta,
 ) {
+  log(`Grafting profile spans into trace ${trace.trace_id}`);
   if (trace.profileGrafted) {
     log(`Trace already has profile grafted ${trace.trace_id}`);
     return;

--- a/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
+++ b/packages/overlay/src/integrations/sentry/data/sentryDataCache.ts
@@ -176,7 +176,6 @@ class SentryDataCache {
 
     if (traceCtx?.trace_id) {
       const existingTrace = this.tracesById.get(traceCtx.trace_id);
-      const startTs = event.start_timestamp ? event.start_timestamp : new Date().getTime();
       const trace = existingTrace ?? {
         ...traceCtx,
         trace_id: traceCtx.trace_id,
@@ -184,13 +183,14 @@ class SentryDataCache {
         spanTree: [] as Span[],
         transactions: [] as SentryTransactionEvent[],
         errors: 0,
+        start_timestamp: event.start_timestamp ?? event.timestamp,
         timestamp: event.timestamp,
-        start_timestamp: startTs,
         status: traceCtx.status,
         rootTransactionName: event.transaction || '(unknown transaction)',
         rootTransaction: null,
         profileGrafted: false,
       };
+      trace.timestamp = Math.max(event.timestamp, trace.timestamp);
 
       if (isTraceEvent(event)) {
         trace.transactions.push(event);
@@ -235,8 +235,6 @@ class SentryDataCache {
       } else if (isErrorEvent(event)) {
         trace.errors += 1;
       }
-      trace.start_timestamp = Math.min(startTs, trace.start_timestamp);
-      trace.timestamp = Math.max(event.timestamp, trace.timestamp);
       if (traceCtx.status !== 'ok') trace.status = traceCtx.status;
 
       const roots = trace.transactions.filter(e => !e.contexts.trace.parent_span_id);
@@ -283,7 +281,9 @@ class SentryDataCache {
           timestamp,
           active_thread_id: txn.active_thread_id,
         });
-        if (trace) {
+        // Avoid grafting partial traces (where we mocked start_timestamp from the event's timestamp)
+        // These should get grafted once we get the full trace data later on
+        if (trace && trace.start_timestamp < trace.timestamp) {
           graftProfileSpans(trace);
         }
       }


### PR DESCRIPTION
Fixes a race condition where we try to graft a trace which was a skeleton generated from a trace context rather than a full trace. This was causing profile frames not getting grafted as the start_timestamp and timestamp values were not set correctly.
