### PR TITLE
fix(overlay) round off condition in Timebar

### DIFF
--- a/.changeset/slow-files-invent.md
+++ b/.changeset/slow-files-invent.md
@@ -1,0 +1,5 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+- Fixed round condition for profiles

--- a/packages/overlay/src/integrations/sentry/components/shared/TimeBar.tsx
+++ b/packages/overlay/src/integrations/sentry/components/shared/TimeBar.tsx
@@ -9,7 +9,8 @@ type TimeBarProps = {
 };
 
 export function TimeBar({ value, maxValue, title, text, className }: TimeBarProps) {
-  const percentage = maxValue !== 0 ? Math.round(value / maxValue) * 100 : 100;
+  const percentage = maxValue !== 0 ? Math.round((value / maxValue) * 100) : 100;
+  console.log(percentage);
   const tooltip = title ?? text ?? '';
 
   return (

--- a/packages/overlay/src/integrations/sentry/components/shared/TimeBar.tsx
+++ b/packages/overlay/src/integrations/sentry/components/shared/TimeBar.tsx
@@ -10,7 +10,6 @@ type TimeBarProps = {
 
 export function TimeBar({ value, maxValue, title, text, className }: TimeBarProps) {
   const percentage = maxValue !== 0 ? Math.round((value / maxValue) * 100) : 100;
-  console.log(percentage);
   const tooltip = title ?? text ?? '';
 
   return (


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

- The earlier condition could only return 0 or 100 for the percentage