### PR TITLE
fix(overlay): Don't use `crypto.randomUUID`

### DIFF
--- a/.changeset/clever-poets-behave.md
+++ b/.changeset/clever-poets-behave.md
@@ -1,0 +1,6 @@
+---
+'@spotlightjs/overlay': patch
+---
+
+`window.crypto` API is only available under secure contexts which prevents Spotlight from being used in dev environments
+w/o https (most of them?). This patch replaces that with our bona fide `generateUuidv4` function

--- a/packages/overlay/src/integrations/console/index.ts
+++ b/packages/overlay/src/integrations/console/index.ts
@@ -1,3 +1,4 @@
+import { generateUuidv4 } from '~/lib/uuid';
 import { trigger } from '../../lib/eventTarget';
 import type { WindowWithSpotlight } from '../../types';
 import type { Integration } from '../integration';
@@ -14,7 +15,7 @@ const CONTENT_TYPE = 'application/x-spotlight-console';
  * @returns Integration Console integration for Spotlight
  */
 export default function consoleIntegration() {
-  const pageloadId = window.crypto.randomUUID();
+  const pageloadId = generateUuidv4();
 
   return {
     name: 'console',

--- a/packages/overlay/src/lib/uuid.ts
+++ b/packages/overlay/src/lib/uuid.ts
@@ -1,6 +1,6 @@
 export function generateUuidv4() {
   let dt = new Date().getTime();
-  return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+  return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, c => {
     let rnd = Math.random() * 16; //random number in range 0 to 16
     rnd = (dt + rnd) % 16 | 0;
     dt = Math.floor(dt / 16);


### PR DESCRIPTION
`window.crypto` API is only available under secure contexts which prevents Spotlight from being used in dev environments w/o https (most of them?). This patch replaces that with our bona fide `generateUuidv4` function. We don't need strong security for these IDs anyway.
