### PR TITLE
fix(overlay): Show selected AI trace when clicking on a AI flow item

### DIFF
--- a/.changeset/strong-phones-nail.md
+++ b/.changeset/strong-phones-nail.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/overlay": patch
+---
+
+Fix click on AI flow item to show its AI trace details

--- a/packages/overlay/src/integrations/sentry/components/insights/aiTraces/AITraceDetails.tsx
+++ b/packages/overlay/src/integrations/sentry/components/insights/aiTraces/AITraceDetails.tsx
@@ -261,11 +261,11 @@ export function AITraceDetailsEmbedded({ spanId }: { spanId: string }) {
       <div className="h-full overflow-y-auto">
         {/* Header Section */}
         <div className="border-b-primary-700 bg-primary-950 border-b px-6 py-4">
-          <div className="mb-2 flex items-center gap-2">
+          <div className="mb-2 flex items-baseline gap-2">
             <h2 className="text-xl font-bold">{handler.getDisplayTitle(trace)}</h2>
+            <span className="text-primary-400 text-sm">{trace.id}</span>
           </div>
           <div className="flex items-center gap-2">
-            <span className="text-primary-400 text-sm">{trace.id}</span>
             <Badge color="primary">{handler.getTypeBadge(trace)}</Badge>
             {trace.metadata.modelId && <Badge color="secondary">{trace.metadata.modelId}</Badge>}
             {trace.metadata.functionId && <Badge color="neutral">{trace.metadata.functionId}</Badge>}

--- a/packages/overlay/src/integrations/sentry/components/insights/aiTraces/AITraceSplitView.tsx
+++ b/packages/overlay/src/integrations/sentry/components/insights/aiTraces/AITraceSplitView.tsx
@@ -52,12 +52,12 @@ export default function AITraceSplitView({ traceId }: AITraceSplitViewProps) {
   return (
     <div className="flex h-full min-h-0">
       {/* left panel - AI flow */}
-      <div className="border-primary-700 flex min-h-0 w-1/2 flex-col border-r">
+      <div className="border-primary-700 flex min-h-0 w-2/5 flex-col border-r">
         <AITraceFlow traceId={traceId} />
       </div>
 
       {/* right panel - AI details */}
-      <div className="flex min-h-0 w-1/2 flex-col">
+      <div className="flex min-h-0 w-3/5 flex-col">
         <AITraceDetailsEmbedded spanId={selectedSpanId} />
       </div>
     </div>

--- a/packages/overlay/src/integrations/sentry/tabs/TracesTab.tsx
+++ b/packages/overlay/src/integrations/sentry/tabs/TracesTab.tsx
@@ -104,6 +104,12 @@ export default function TracesTab() {
   return (
     <SentryEventsContextProvider>
       <Routes>
+        {/* Route for when clicking AI flow / messages. This shows that particular ai trace details */}
+        <Route
+          path="/:traceId/spans/:spanId"
+          element={<TraceSplitViewLayout aiMode={aiMode} onToggleAIMode={handleToggleAIMode} />}
+        />
+        {/* AI Trace id w/o subpaths */}
         <Route
           path="/:traceId/*"
           element={<TraceSplitViewLayout aiMode={aiMode} onToggleAIMode={handleToggleAIMode} />}


### PR DESCRIPTION
#804 was supposed to include this behaviour. Video below:

https://github.com/user-attachments/assets/6c3d02bc-ee54-40b8-b628-c0a05ccde33d



Before opening this PR:
- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [x] I referenced issues that this PR addresses
