### PR TITLE
ref(overlay): Restore routing for traces and spans

### DIFF
--- a/.changeset/smart-rabbits-work.md
+++ b/.changeset/smart-rabbits-work.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/overlay": patch
+---
+
+Restore react-router routing

--- a/.cursor/rules/.cursor/rules/routing.mdc
+++ b/.cursor/rules/.cursor/rules/routing.mdc
@@ -1,0 +1,15 @@
+---
+description: 
+globs: 
+alwaysApply: false
+---
+## Routing
+Use React Router v6 (with MemoryRouter) for all routing logic.
+
+Details:
+	•	Use <Routes> and <Route> to define all navigable views.
+	•	Use <Link> or useNavigate for navigation — do not manually manage routing state like selectedTrace or similar in local component state.
+	•	When possible, extract state from the URL using useParams or useSearchParams instead of passing props or using global state.
+	•	Treat the URL as the source of truth for navigation-related state (e.g. selected items, tabs, filters, etc).
+
+Examples of routing: [TraceItem.tsx](mdc:packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx) [index.tsx](mdc:packages/overlay/src/integrations/sentry/components/traces/TraceDetails/index.tsx) 

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx
@@ -68,6 +68,8 @@ export default function TraceItem({ trace, isSelected = false, className }: Trac
     </>
   );
 
+  // TODO: For this #<traceId> link to work as intended, we need to do something like this:
+  //       https://dev.to/mindactuate/scroll-to-anchor-element-with-react-router-v6-38op
   return (
     <Link
       className={classNames(

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useParams } from "react-router-dom";
 import { Badge } from "~/ui/badge";
 import TimeSince from "../../../../components/TimeSince";
 import classNames from "../../../../lib/classNames";
@@ -13,20 +13,12 @@ import TraceIcon from "./TraceIcon";
 type TraceItemProps = {
   trace: Trace;
   isSelected?: boolean;
-  onClick?: () => void;
   className?: string;
-  href?: string;
-  asLink?: boolean;
 };
 
-export default function TraceItem({
-  trace,
-  isSelected = false,
-  onClick,
-  className,
-  href,
-  asLink = false,
-}: TraceItemProps) {
+export default function TraceItem({ trace, isSelected = false, className }: TraceItemProps) {
+  const { spanId } = useParams<{ spanId: string }>();
+
   const duration = getFormattedSpanDuration(trace);
   const truncatedId = truncateId(trace.trace_id);
   const isLocal = isLocalTrace(trace.trace_id);
@@ -76,23 +68,16 @@ export default function TraceItem({
     </>
   );
 
-  const wrapperClassName = classNames(
-    "hover:bg-primary-900 flex cursor-pointer items-center gap-x-4 px-6 py-2",
-    isSelected && "bg-primary-800",
-    className,
-  );
-
-  if (asLink && href) {
-    return (
-      <Link className={wrapperClassName} to={href}>
-        {content}
-      </Link>
-    );
-  }
-
   return (
-    <div className={wrapperClassName} onClick={onClick}>
+    <Link
+      className={classNames(
+        "hover:bg-primary-900 flex cursor-pointer items-center gap-x-4 px-6 py-2",
+        isSelected && "bg-primary-800",
+        className,
+      )}
+      to={isSelected && !spanId ? `../#${trace.trace_id}` : `/traces/${trace.trace_id}/context`}
+    >
       {content}
-    </div>
+    </Link>
   );
 }

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceItem.tsx
@@ -12,13 +12,12 @@ import TraceIcon from "./TraceIcon";
 
 type TraceItemProps = {
   trace: Trace;
-  isSelected?: boolean;
   className?: string;
 };
 
-export default function TraceItem({ trace, isSelected = false, className }: TraceItemProps) {
-  const { spanId } = useParams<{ spanId: string }>();
-
+export default function TraceItem({ trace, className }: TraceItemProps) {
+  const { traceId, spanId } = useParams<{ traceId: string; spanId: string }>();
+  const isSelected = traceId === trace.trace_id;
   const duration = getFormattedSpanDuration(trace);
   const truncatedId = truncateId(trace.trace_id);
   const isLocal = isLocalTrace(trace.trace_id);

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
@@ -51,7 +51,7 @@ export default function TraceList({ traceData, displayConfig, onShowAll }: Trace
 
             return (
               <div key={trace.trace_id} ref={isSelected ? selectedTraceRef : null}>
-                <TraceItem trace={trace} isSelected={isSelected} />
+                <TraceItem trace={trace} />
 
                 {/* Inline content below selected trace */}
                 {isSelected && !displayConfig.hideSelectedInline && (

--- a/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
+++ b/packages/overlay/src/integrations/sentry/components/traces/TraceList.tsx
@@ -49,8 +49,6 @@ export default function TraceList({ traceData, displayConfig, onShowAll }: Trace
             const traceData = getTraceById(trace.trace_id);
             const isAITrace = traceData ? hasAISpans(traceData) : false;
 
-            // TODO: For this #<traceId> link to work as intended, we need to do something like this:
-            //       https://dev.to/mindactuate/scroll-to-anchor-element-with-react-router-v6-38op
             return (
               <div key={trace.trace_id} ref={isSelected ? selectedTraceRef : null}>
                 <TraceItem trace={trace} isSelected={isSelected} />

--- a/packages/overlay/src/integrations/sentry/tabs/TracesTab.tsx
+++ b/packages/overlay/src/integrations/sentry/tabs/TracesTab.tsx
@@ -80,7 +80,7 @@ function TraceSplitViewLayout({ traceData, aiConfig, onShowAll }: TraceSplitView
         <div className="border-b-primary-700 bg-primary-900 border-b transition-colors duration-150">
           <div className="flex items-center bg-primary-800">
             <div className="flex-1">
-              <TraceItem trace={selectedTrace} isSelected={true} className="hover:bg-transparent" />
+              <TraceItem trace={selectedTrace} className="hover:bg-transparent" />
             </div>
 
             {/* AI Mode Toggle */}

--- a/packages/overlay/src/integrations/sentry/tabs/TracesTab.tsx
+++ b/packages/overlay/src/integrations/sentry/tabs/TracesTab.tsx
@@ -26,6 +26,7 @@ interface TraceSplitViewLayoutProps {
     filtered: Trace[];
     all: Trace[];
     visible: Trace[];
+    hiddenItemCount: number;
   };
   aiConfig: {
     mode: boolean;
@@ -57,13 +58,6 @@ function TraceSplitViewLayout({ traceData, aiConfig, onShowAll }: TraceSplitView
     navigate(".."); // relative to /:traceId/*, so goes to TracesTab
   }, [navigate]);
 
-  const handleTraceSelect = useCallback(
-    (traceId: string) => {
-      navigate(`../${traceId}`); // Navigate up one level, then to the new trace
-    },
-    [navigate],
-  );
-
   // Scroll to top when trace changes
   useEffect(() => {
     if (leftPanelRef.current) {
@@ -86,12 +80,7 @@ function TraceSplitViewLayout({ traceData, aiConfig, onShowAll }: TraceSplitView
         <div className="border-b-primary-700 bg-primary-900 border-b transition-colors duration-150">
           <div className="flex items-center bg-primary-800">
             <div className="flex-1">
-              <TraceItem
-                trace={selectedTrace}
-                isSelected={true}
-                onClick={handleCloseTraceDetails}
-                className="hover:bg-transparent"
-              />
+              <TraceItem trace={selectedTrace} isSelected={true} className="hover:bg-transparent" />
             </div>
 
             {/* AI Mode Toggle */}
@@ -153,8 +142,6 @@ function TraceSplitViewLayout({ traceData, aiConfig, onShowAll }: TraceSplitView
           {/* Bottom part of left panel: Trace List */}
           <div className="flex-shrink-0">
             <TraceList
-              onTraceSelect={handleTraceSelect}
-              selectedTraceId={traceId}
               traceData={traceData}
               displayConfig={{
                 aiMode: aiConfig.mode,
@@ -189,36 +176,25 @@ function TraceSplitViewLayout({ traceData, aiConfig, onShowAll }: TraceSplitView
 
 interface TraceListOnlyViewProps {
   aiMode: boolean;
-  filteredTraces: Trace[];
-  allTraces: Trace[];
-  visibleTraces: Trace[];
-  setShowAll: React.Dispatch<React.SetStateAction<boolean>>;
+  traceData: {
+    filtered: Trace[];
+    all: Trace[];
+    visible: Trace[];
+    hiddenItemCount: number;
+  };
+  onShowAll: () => void;
 }
 
-function TraceListOnlyView({ aiMode, filteredTraces, allTraces, visibleTraces, setShowAll }: TraceListOnlyViewProps) {
-  const navigate = useNavigate();
-  const handleTraceSelect = useCallback(
-    (traceId: string) => {
-      navigate(`../${traceId}`); // Navigate up one level, then to the new trace
-    },
-    [navigate],
-  );
-
+function TraceListOnlyView({ aiMode, traceData, onShowAll }: TraceListOnlyViewProps) {
   return (
     <div className="h-full w-full overflow-y-auto">
       <TraceList
-        onTraceSelect={handleTraceSelect}
-        selectedTraceId={undefined}
-        traceData={{
-          filtered: filteredTraces,
-          all: allTraces,
-          visible: visibleTraces,
-        }}
+        traceData={traceData}
         displayConfig={{
           aiMode: aiMode,
           hideSelectedInline: false,
         }}
-        onShowAll={() => setShowAll(true)}
+        onShowAll={onShowAll}
       />
     </div>
   );
@@ -237,6 +213,14 @@ export default function TracesTab() {
   const [searchQuery, setSearchQuery] = useState("");
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
   const { TRACE_FILTER_CONFIGS, filteredTraces } = useTraceFiltering(visibleTraces, activeFilters, searchQuery);
+  const hiddenItemCount = allTraces.length - visibleTraces.length;
+
+  const traceData = {
+    filtered: filteredTraces,
+    all: allTraces,
+    visible: visibleTraces,
+    hiddenItemCount: hiddenItemCount,
+  };
 
   return (
     <SentryEventsContextProvider>
@@ -255,11 +239,7 @@ export default function TracesTab() {
               path="/:traceId/spans/:spanId"
               element={
                 <TraceSplitViewLayout
-                  traceData={{
-                    filtered: filteredTraces,
-                    all: allTraces,
-                    visible: visibleTraces,
-                  }}
+                  traceData={traceData}
                   aiConfig={{
                     mode: aiMode,
                     onToggle: handleToggleAIMode,
@@ -272,11 +252,7 @@ export default function TracesTab() {
               path="/:traceId/*"
               element={
                 <TraceSplitViewLayout
-                  traceData={{
-                    filtered: filteredTraces,
-                    all: allTraces,
-                    visible: visibleTraces,
-                  }}
+                  traceData={traceData}
                   aiConfig={{
                     mode: aiMode,
                     onToggle: handleToggleAIMode,
@@ -287,25 +263,13 @@ export default function TracesTab() {
             />
             <Route
               path="/"
-              element={
-                <TraceListOnlyView
-                  aiMode={aiMode}
-                  filteredTraces={filteredTraces}
-                  allTraces={allTraces}
-                  visibleTraces={visibleTraces}
-                  setShowAll={setShowAll}
-                />
-              }
+              element={<TraceListOnlyView aiMode={aiMode} traceData={traceData} onShowAll={() => setShowAll(true)} />}
             />
             <Route
               path="/:traceId/spans/:spanId/*"
               element={
                 <TraceSplitViewLayout
-                  traceData={{
-                    filtered: filteredTraces,
-                    all: allTraces,
-                    visible: visibleTraces,
-                  }}
+                  traceData={traceData}
                   aiConfig={{
                     mode: aiMode,
                     onToggle: handleToggleAIMode,


### PR DESCRIPTION
I completely destroyed @BYK routing done in #831 . This should restore it.

Added a short cursor rule for routing. I haven't used it yet (I thought about it once I created the PR) but it should be better than not having one.  We could keep adding rules for different topics. 

Next I'll create a hook for traceData as per https://github.com/getsentry/spotlight/pull/831#discussion_r2132878766 to clean up  `TracesTab`

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
