### PR TITLE
Added installation docs for Magento

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -115,6 +115,10 @@ export default defineConfig({
               link: "/setup/laravel/",
             },
             {
+              label: "For Magento",
+              link: "/setup/magento/",
+            },
+            {
               label: "For Astro",
               link: "/setup/astro/",
             },

--- a/packages/website/src/content/docs/setup/index.mdx
+++ b/packages/website/src/content/docs/setup/index.mdx
@@ -18,6 +18,11 @@ Spotlight is language and framework agnostic, but we've made it work even better
   description="Setup Spotlight in Laravel."
 />
 <LinkCard
+  title="Magento"
+  href="./magento/"
+  description="Setup Spotlight in Magento."
+/>
+<LinkCard
   title="Astro"
   href="./astro/"
   description="Spotlight integrates automatically with Astro's Dev Toolbar."

--- a/packages/website/src/content/docs/setup/magento.mdx
+++ b/packages/website/src/content/docs/setup/magento.mdx
@@ -1,0 +1,69 @@
+---
+title: Using Spotlight with Magento
+description: A guide on how to setup Spotlight for Magento
+---
+
+import { Content as InstallCommand } from "../../../components/InstallCommand.mdx";
+import { Tabs, TabItem } from "@astrojs/starlight/components";
+
+This guide gets Spotlight up and running in Magento with Sentry SDK.
+
+## 1. Installation
+
+### Install Sentry SDK
+
+Follow the [Magento Installation](https://github.com/justbetter/magento2-sentry#installation) guide to install and configure the Sentry SDK for Magento.
+
+Note that you don't need a DSN or don't need to sign up for Sentry to use Spotlight. If you already have Sentry SDK installed, make sure you have a recent version.
+
+### Get and Run Spotlight
+
+<Tabs>
+  <TabItem label="npx">```shell npx @spotlightjs/spotlight ```</TabItem>
+  <TabItem label="docker">
+    ```shell docker run --rm -p 8969 ghcr.io/getsentry/spotlight:latest ```
+  </TabItem>
+  <TabItem label="binary">
+    ```shell curl -q https://spotlightjs.com/install.sh | sh ```
+  </TabItem>
+</Tabs>
+
+## 2. Enable Spotlight
+
+### Configure Sentry
+
+In your `app/etc/env.php` file, add the spotlight configuration:
+
+```php
+'sentry' => [
+  ...
+  'spotlight' => true
+]
+```
+
+Or alternatively add the `CONFIG__SENTRY__ENVIRONMENT__SPOTLIGHT` environment variable to environment
+
+```env
+CONFIG__SENTRY__ENVIRONMENT__SPOTLIGHT=true
+```
+
+That's it! As long as Spotlight is running, and Magento is not running in production mode[^1], the Magento integration will automatically inject Spotlight into your UI.
+
+### Additional Configuration
+
+If you need to run Spotlight on a different port or domain, you can specify a Spotlight URL:
+
+```php
+'sentry' => [
+  ...
+  'spotlight_url' => 'http://localhost:3839/stream'
+]
+```
+
+or
+
+```env
+CONFIG__SENTRY__ENVIRONMENT__SPOTLIGHT_URL=http://localhost:3839/stream
+```
+
+[^1]: This requirement is to prevent enabling Spotlight accidentally on production environments.


### PR DESCRIPTION
To preface, i'm not sure wether docs for usage with third-party Sentry integrations are wanted. If not, feel free to close this PR.

This PR adds docs for enabling Spotlight with Magento using the [justbetter/magento2-sentry](https://github.com/justbetter/magento2-sentry) php package