### PR TITLE
fix(overlay): Don't crash on missing stracktrace.frames

### DIFF
--- a/.changeset/quiet-sides-sink.md
+++ b/.changeset/quiet-sides-sink.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/overlay": patch
+---
+
+Fix crash on the rare case when an exception has a stacktrace property but not frames under it

--- a/packages/overlay/src/integrations/sentry/store/slices/sharedSlice.ts
+++ b/packages/overlay/src/integrations/sentry/store/slices/sharedSlice.ts
@@ -23,14 +23,12 @@ export const createSharedSlice: StateCreator<SentryStore, [], [], SharedSliceAct
 
     await Promise.all(
       (errorEvent.exception.values ?? []).map(async exception => {
-        if (!exception.stacktrace) {
+        if (!exception.stacktrace || !exception.stacktrace.frames) {
           return;
         }
         exception.stacktrace.frames.reverse();
 
-        if (
-          exception.stacktrace.frames?.every(frame => frame.post_context && frame.pre_context && frame.context_line)
-        ) {
+        if (exception.stacktrace.frames.every(frame => frame.post_context && frame.pre_context && frame.context_line)) {
           log("Skipping contextlines request as we have full context for", exception);
           return;
         }


### PR DESCRIPTION
Fixes SPOTLIGHT-CLI-1J
