### PR TITLE
feat(sidecar): improve CLI argument parsing with native parseArgs

### DIFF
--- a/packages/sidecar/README.md
+++ b/packages/sidecar/README.md
@@ -10,9 +10,40 @@ npm install @spotlightjs/sidecar
 
 ## Usage
 
+### As a Library
+
 ```js
 import { setupSidecar } from '@spotlightjs/sidecar';
 
 // When you start your dev server
 setupSidecar();
 ```
+
+### As a CLI
+
+```bash
+# Start with default settings (port 8969)
+spotlight-sidecar
+
+# Start on a custom port
+spotlight-sidecar --port 3000
+# or
+spotlight-sidecar -p 3000
+
+# Enable debug logging
+spotlight-sidecar --debug
+# or
+spotlight-sidecar -d
+
+# Combine options
+spotlight-sidecar --port 3000 --debug
+
+# Show help
+spotlight-sidecar --help
+```
+
+### CLI Options
+
+- `-p, --port <port>` - Port to listen on (default: 8969)
+- `-d, --debug` - Enable debug logging
+- `-h, --help` - Show help message

--- a/packages/sidecar/server.ts
+++ b/packages/sidecar/server.ts
@@ -43,10 +43,23 @@ Examples:
 }
 
 // Handle legacy positional argument for port (backwards compatibility)
-const port = positionals.length > 0 ? Number(positionals[0]) : Number(values.port);
+const portInput = positionals.length > 0 ? positionals[0] : values.port;
+const port = Number(portInput);
+
+// Validate port number
+if (Number.isNaN(port)) {
+  console.error(`Error: Invalid port number '${portInput}'`);
+  console.error("Port must be a valid number between 1 and 65535");
+  process.exit(1);
+}
+
+if (port < 1 || port > 65535) {
+  console.error(`Error: Port ${port} is out of valid range (1-65535)`);
+  process.exit(1);
+}
 
 setupSidecar({
-  port: Number.isNaN(port) ? undefined : port,
+  port,
   debug: values.debug,
   isStandalone: true,
 });

--- a/packages/sidecar/server.ts
+++ b/packages/sidecar/server.ts
@@ -1,5 +1,52 @@
 #!/usr/bin/env node
+import { parseArgs } from "node:util";
 import { setupSidecar } from "./src/main.js";
 
-const port = process.argv.length >= 3 ? Number(process.argv[2]) : undefined;
-setupSidecar({ port, isStandalone: true });
+const { values, positionals } = parseArgs({
+  options: {
+    port: {
+      type: "string",
+      short: "p",
+      default: "8969",
+    },
+    debug: {
+      type: "boolean",
+      short: "d",
+      default: false,
+    },
+    help: {
+      type: "boolean",
+      short: "h",
+      default: false,
+    },
+  },
+  allowPositionals: true,
+});
+
+if (values.help) {
+  console.log(`
+Spotlight Sidecar - Development proxy server for Spotlight
+
+Usage: spotlight-sidecar [options]
+
+Options:
+  -p, --port <port>    Port to listen on (default: 8969)
+  -d, --debug          Enable debug logging
+  -h, --help           Show this help message
+
+Examples:
+  spotlight-sidecar                    # Start on default port 8969
+  spotlight-sidecar --port 3000        # Start on port 3000
+  spotlight-sidecar -p 3000 -d         # Start on port 3000 with debug logging
+`);
+  process.exit(0);
+}
+
+// Handle legacy positional argument for port (backwards compatibility)
+const port = positionals.length > 0 ? Number(positionals[0]) : Number(values.port);
+
+setupSidecar({
+  port: Number.isNaN(port) ? undefined : port,
+  debug: values.debug,
+  isStandalone: true,
+});


### PR DESCRIPTION
## Summary
- Replace basic positional argument parsing with Node.js native `parseArgs` utility
- Add proper CLI flags for port and debug mode configuration
- Provide help documentation for CLI users

## Changes
- **Port flag**: `--port/-p` to set custom port (default: 8969)
- **Debug flag**: `--debug/-d` to enable debug logging
- **Help flag**: `--help/-h` to display usage information
- **Backwards compatibility**: Legacy positional port argument still works
- **Documentation**: Updated README with comprehensive CLI usage examples

## Implementation Details
Using Node.js native `util.parseArgs()` (stable since Node.js 20) to avoid adding external dependencies while providing a clean, professional CLI experience. The project requires Node.js >= 22, so this native solution is ideal.

## Test Plan
- [x] Tested `--help` flag displays usage information
- [x] Verified build completes successfully
- [x] All existing tests pass
- [x] Backwards compatibility with positional port argument maintained