### PR TITLE
fix: added parsing and format exports in the tsdown config

### DIFF
--- a/packages/sidecar/tsdown.config.ts
+++ b/packages/sidecar/tsdown.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from "tsdown";
 
 export default defineConfig({
-  entry: ["./src/main.ts", "./src/vite-plugin.ts", "./src/constants.ts", "./server.ts"],
+  entry: [
+    "./src/main.ts",
+    "./src/vite-plugin.ts",
+    "./src/constants.ts",
+    "./server.ts",
+    "./src/parser/index.ts",
+    "./src/format/index.ts",
+  ],
   sourcemap: true,
 });


### PR DESCRIPTION
Added parsing and format files export in the tsdown config as these were not getting bundled correctly. This was missed in the PR #920 