### PR TITLE
ref(overlay): small cleanup

### DIFF
--- a/.changeset/silly-bobcats-pay.md
+++ b/.changeset/silly-bobcats-pay.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/overlay": patch
+---
+
+Refactor to remove object destructuring from hooks returning only one value

--- a/packages/overlay/src/telemetry/components/insights/Queries.tsx
+++ b/packages/overlay/src/telemetry/components/insights/Queries.tsx
@@ -44,7 +44,7 @@ const calculateQueryInfo = ({ query, spanData }: { query: string; spanData: Span
 
 const Queries = () => {
   const navigate = useNavigate();
-  const { allSpans } = useSentrySpans();
+  const allSpans = useSentrySpans();
   const { sort, toggleSortOrder } = useSort({ defaultSortType: QUERIES_SORT_KEYS.totalTime });
 
   const queriesData: QueryInfo[] = useMemo(() => {

--- a/packages/overlay/src/telemetry/components/insights/QuerySummary.tsx
+++ b/packages/overlay/src/telemetry/components/insights/QuerySummary.tsx
@@ -32,7 +32,7 @@ const COMPARATORS: Record<QuerySummarySortTypes, SpanInfoComparator> = {
 };
 
 const QuerySummary = () => {
-  const { allSpans } = useSentrySpans();
+  const allSpans = useSentrySpans();
   const { type } = useParams();
   const { sort, toggleSortOrder } = useSort({ defaultSortType: QUERY_SUMMARY_SORT_KEYS.totalTime });
 

--- a/packages/overlay/src/telemetry/components/insights/Resources.tsx
+++ b/packages/overlay/src/telemetry/components/insights/Resources.tsx
@@ -69,7 +69,7 @@ const COMPARATORS: Record<ResourceSortTypes, ResourceInfoComparator> = {
 };
 
 const Resources = () => {
-  const { allSpans } = useSentrySpans();
+  const allSpans = useSentrySpans();
   const { sort, toggleSortOrder } = useSort({ defaultSortType: RESOURCES_SORT_KEYS.totalTime });
 
   const resources = useMemo(() => {

--- a/packages/overlay/src/telemetry/components/insights/envelopes/EnvelopeList.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/EnvelopeList.tsx
@@ -12,7 +12,7 @@ import EnvelopeDetails from "./EnvelopeDetails";
 
 export default function EnvelopeList() {
   const { id: selectedEnvelopeId } = useParams();
-  const { allEnvelopes } = useSentryEnvelopes();
+  const allEnvelopes = useSentryEnvelopes();
   const { getEnvelopeById } = useSentryStore();
 
   const selectedEnvelope = selectedEnvelopeId ? getEnvelopeById(selectedEnvelopeId) : null;

--- a/packages/overlay/src/telemetry/components/log/LogsList.tsx
+++ b/packages/overlay/src/telemetry/components/log/LogsList.tsx
@@ -31,7 +31,7 @@ const COMPARATORS: Record<LogsSortTypes, LogsComparator> = {
 const LogsList = ({ traceId }: { traceId?: string }) => {
   const { id: selectedLogId } = useParams();
   const navigate = useNavigate();
-  const { allLogs } = useSentryLogs(traceId);
+  const allLogs = useSentryLogs(traceId);
   const { sort, toggleSortOrder } = useSort({ defaultSortType: LOGS_SORT_KEYS.timestamp });
 
   const logsData = useMemo(() => {

--- a/packages/overlay/src/telemetry/components/traces/TraceDetails/index.tsx
+++ b/packages/overlay/src/telemetry/components/traces/TraceDetails/index.tsx
@@ -68,7 +68,7 @@ export default function TraceDetails({ trace, aiConfig }: TraceDetailsProps) {
 
   const events = useSentryEvents(trace.trace_id);
   const profile = useSentryStore.getState().getProfileByTraceId(trace.trace_id);
-  const errorCount = useMemo(() => events.filter(e => isErrorEvent(e)).length, [events]);
+  const errorCount = useMemo(() => events.reduce((len, e) => (isErrorEvent(e) ? len + 1 : len), 0), [events]);
 
   const tabs = [
     createTab("context", "Context"),

--- a/packages/overlay/src/telemetry/data/useSentryEnvelopes.tsx
+++ b/packages/overlay/src/telemetry/data/useSentryEnvelopes.tsx
@@ -15,5 +15,5 @@ export const useSentryEnvelopes = () => {
     return 0;
   });
 
-  return { allEnvelopes };
+  return allEnvelopes;
 };

--- a/packages/overlay/src/telemetry/data/useSentryLogs.tsx
+++ b/packages/overlay/src/telemetry/data/useSentryLogs.tsx
@@ -8,9 +8,7 @@ export const useSentryLogs = (traceId?: string) => {
 
   const allLogs = Array.from(traceId ? getLogsByTraceId(traceId) : getLogs());
 
-  return {
-    allLogs,
-  };
+  return allLogs;
 };
 
 export const useSentryLog = (id: string) => {

--- a/packages/overlay/src/telemetry/data/useSentrySpans.ts
+++ b/packages/overlay/src/telemetry/data/useSentrySpans.ts
@@ -8,7 +8,7 @@ export function useSentryTraces() {
   const { getTraces } = useSentryStore();
   const allTraces = getTraces();
 
-  return { allTraces };
+  return allTraces;
 }
 
 function spanReducer(acc: Span[], trace: Trace) {
@@ -23,13 +23,13 @@ function spanCountReducer(sum: number, trace: Trace) {
 }
 
 export const useSentrySpans = () => {
-  const { allTraces } = useSentryTraces();
+  const allTraces = useSentryTraces();
   const allSpans: Span[] = allTraces.reduce(spanReducer, []);
-  return { allSpans };
+  return allSpans;
 };
 
 export const useSentrySpanCounts = () => {
-  const { allTraces } = useSentryTraces();
+  const allTraces = useSentryTraces();
 
   return {
     allSpans: allTraces.reduce(spanCountReducer, 0),

--- a/packages/overlay/src/telemetry/data/useSpotlightAITraces.ts
+++ b/packages/overlay/src/telemetry/data/useSpotlightAITraces.ts
@@ -4,7 +4,7 @@ import type { Span, SpotlightAITrace } from "../types";
 import { useSentryTraces } from "./useSentrySpans";
 
 export function useAITraces(): Span[] {
-  const { allTraces } = useSentryTraces();
+  const allTraces = useSentryTraces();
 
   return useMemo(() => {
     const rootSpans: Span[] = [];

--- a/packages/overlay/src/telemetry/tabs/TracesTab.tsx
+++ b/packages/overlay/src/telemetry/tabs/TracesTab.tsx
@@ -141,7 +141,7 @@ export function TraceSplitViewLayout({ trace, span, aiConfig }: TraceSplitViewLa
 }
 
 export default function TracesTab() {
-  const { allTraces } = useSentryTraces();
+  const allTraces = useSentryTraces();
   const [searchQuery, setSearchQuery] = useState("");
   const [activeFilters, setActiveFilters] = useState<string[]>([]);
   const { TRACE_FILTER_CONFIGS, filteredTraces } = useTraceFiltering(allTraces, activeFilters, searchQuery);


### PR DESCRIPTION
#924 follow up.

- Replaced destructured usage of `allSpans`, `allTraces`, `allLogs` and `allEnvelopes` from their respective hooks with a direct assignment.
- simplified `errorCount` calculation.
