### PR TITLE
electron(fix): draggable electron window

### DIFF
--- a/.changeset/major-jokes-rescue.md
+++ b/.changeset/major-jokes-rescue.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/electron": minor
+---
+
+Make app window draggable

--- a/packages/electron/src/electron/main/index.ts
+++ b/packages/electron/src/electron/main/index.ts
@@ -47,7 +47,6 @@ const createWindow = () => {
       sandbox: false,
     },
     backgroundColor: "#1e1b4b",
-    ...(process.platform !== "darwin" ? { titleBarOverlay: true } : {}),
   });
 
   // win.webContents.openDevTools();

--- a/packages/electron/src/electron/main/index.ts
+++ b/packages/electron/src/electron/main/index.ts
@@ -77,28 +77,25 @@ const createWindow = () => {
 
   win.webContents.on("did-finish-load", () => {
     win.webContents.executeJavaScript(
-      `// Create a draggable header bar at the top of the window
-      const spotlightDebugger = document.querySelector('.spotlight-debugger');
-      if (spotlightDebugger) {
-        const dragHandle = document.createElement('div');
-        dragHandle.style.cssText = \`
-          position: fixed;
-          top: 0;
-          left: 0;
-          right: 0;
-          height: 32px;
-          -webkit-app-region: drag;
-          z-index: 9999;
-          background: transparent;
-        \`;
-        dragHandle.id = 'electron-drag-handle';
-        
-        if (!document.getElementById('electron-drag-handle')) {
-          document.body.appendChild(dragHandle);
-        }
-        
-        spotlightDebugger.style.paddingTop = '32px';
-      }`,
+      `const spotlightRoot = document.getElementById('spotlight-root');
+       if (spotlightRoot) {
+         const dragHandle = document.createElement('div');
+         dragHandle.style.cssText = \`
+           position: fixed;
+           top: 0;
+           left: 0;
+           right: 0;
+           height: 32px;
+           -webkit-app-region: drag;
+           z-index: 9999;
+           background: transparent;
+         \`;
+         dragHandle.id = 'electron-drag-handle';
+         
+         if (!document.getElementById('electron-drag-handle')) {
+           document.body.appendChild(dragHandle);
+         }
+       }`,
     );
   });
 };
@@ -326,7 +323,7 @@ store.onDidChange("sentry-send-envelopes", newValue => {
 const showErrorMessage = () => {
   if (win) {
     win.webContents.executeJavaScript(`{
-      const sentryRoot = document.getElementById('sentry-spotlight-root');
+      const sentryRoot = document.getElementById('spotlight-root');
       const errorScreen = document.getElementById('error-screen');
       if (sentryRoot) {
         sentryRoot.style.display = 'none';

--- a/packages/electron/src/electron/main/index.ts
+++ b/packages/electron/src/electron/main/index.ts
@@ -47,6 +47,7 @@ const createWindow = () => {
       sandbox: false,
     },
     backgroundColor: "#1e1b4b",
+    ...(process.platform !== "darwin" ? { titleBarOverlay: true } : {}),
   });
 
   // win.webContents.openDevTools();

--- a/packages/electron/src/electron/main/index.ts
+++ b/packages/electron/src/electron/main/index.ts
@@ -77,10 +77,28 @@ const createWindow = () => {
 
   win.webContents.on("did-finish-load", () => {
     win.webContents.executeJavaScript(
-      `const firstChild = document.querySelector('#sentry-spotlight-root')?.shadowRoot?.querySelector('.spotlight-fullscreen > :first-child');
-        if(firstChild) {
-          firstChild.style.cssText = 'padding-top: 34px; -webkit-app-region:drag;'
-        }`,
+      `// Create a draggable header bar at the top of the window
+      const spotlightDebugger = document.querySelector('.spotlight-debugger');
+      if (spotlightDebugger) {
+        const dragHandle = document.createElement('div');
+        dragHandle.style.cssText = \`
+          position: fixed;
+          top: 0;
+          left: 0;
+          right: 0;
+          height: 32px;
+          -webkit-app-region: drag;
+          z-index: 9999;
+          background: transparent;
+        \`;
+        dragHandle.id = 'electron-drag-handle';
+        
+        if (!document.getElementById('electron-drag-handle')) {
+          document.body.appendChild(dragHandle);
+        }
+        
+        spotlightDebugger.style.paddingTop = '32px';
+      }`,
     );
   });
 };


### PR DESCRIPTION
Last week, when removing the overlay feature (and some shadow dom stuff), I renamed the `id` of the app root to `"spotlight-root"` in `packages/overlay/src/index.tsx`:

```typescript
  const appRoot = document.createElement("div");
  appRoot.id = "spotlight-root";
```

I didn't do a pass on the electron package, missing that the drag feature was based on getting this id.