### PR TITLE
feat: Support for more raw attachment types

### DIFF
--- a/.changeset/six-adults-return.md
+++ b/.changeset/six-adults-return.md
@@ -1,0 +1,8 @@
+---
+"@spotlightjs/electron": minor
+"@spotlightjs/overlay": minor
+"@spotlightjs/sidecar": minor
+"@spotlightjs/spotlight": minor
+---
+
+More attachment type support: suppresses JSON parse errors from statsd and replay_video event types and displays statsd data as text

--- a/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
@@ -1,15 +1,23 @@
 import type { EnvelopeItem } from "@sentry/core";
 
 export default function Attachment({ header, attachment }: { header: EnvelopeItem[0]; attachment: string }) {
+  let text: string | null = null;
   if (header.content_type === "text/plain") {
-    return (
-      <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm p-2 bg-primary-900 rounded-sm">
-        {attachment}
-      </pre>
-    );
+    text = attachment;
+    // @ts-expect-error ts(2367) -- statsd is an old and deprecated event type
+  } else if (header.type! === "statsd") {
+    text = atob(attachment);
   }
 
-  const src = `data:${header.content_type};base64,${attachment}`;
-
-  return <img src={src} alt="Attachment" className="w-full h-full object-contain" />;
+  return text != null ? (
+    <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm p-2 bg-primary-900 rounded-sm">
+      {text}
+    </pre>
+  ) : (
+    <img
+      src={`data:${header.content_type};base64,${attachment}`}
+      alt="Attachment"
+      className="w-full h-full object-contain"
+    />
+  );
 }

--- a/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
@@ -1,34 +1,43 @@
 import type { EnvelopeItem } from "@sentry/core";
+import { type ReactNode, useEffect, useMemo } from "react";
+import { ReactComponent as Download } from "~/assets/download.svg";
 import JsonViewer from "../../shared/JsonViewer";
-import type { ReactNode } from "react";
 
 export default function Attachment({ header, attachment }: { header: EnvelopeItem[0]; attachment: string }) {
   let content: ReactNode | null = null;
-  const name = (header.filename as string) || "<unknown>";
+  let extension = "bin";
   if (header.content_type === "text/plain") {
+    extension = "txt";
     content = (
       <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm p-2 bg-primary-900 rounded-sm">
         {attachment}
       </pre>
     );
   } else if (header.content_type === "application/json") {
+    extension = "json";
     content = <JsonViewer data={JSON.parse(attachment)} />;
-  } else {
-    // we don't know what this is to just provide a download button
-    const downloadUrl = URL.createObjectURL(
-      new Blob([atob(attachment)], { type: (header.content_type as string) || "application/octet-stream" }),
-    );
-    const downloadName = `${name}.bin`;
-    content = (
-      <a href={downloadUrl} download={downloadName}>
-        Download
-      </a>
-    );
   }
+  const name = (header.filename as string) || `untitled-attachment.${extension}`;
+
+  const downloadUrl = useMemo(
+    () =>
+      URL.createObjectURL(
+        new Blob([extension === "bin" ? atob(attachment) : attachment], {
+          type: (header.content_type as string) || "application/octet-stream",
+        }),
+      ),
+    [attachment, header.content_type, extension],
+  );
+  useEffect(() => () => URL.revokeObjectURL(downloadUrl), [downloadUrl]);
 
   return (
     <>
-      <h3>📎 {name}</h3>
+      <h3>
+        📎{" "}
+        <a href={downloadUrl} download={name}>
+          {name} <Download className="w-4 h-4 opacity-60 group-hover:opacity-100 transition-opacity inline" />
+        </a>
+      </h3>
       {content}
     </>
   );

--- a/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
@@ -13,6 +13,17 @@ export default function Attachment({ header, attachment }: { header: EnvelopeIte
     );
   } else if (header.content_type === "application/json") {
     content = <JsonViewer data={JSON.parse(attachment)} />;
+  } else {
+    // we don't know what this is to just provide a download button
+    const downloadUrl = URL.createObjectURL(
+      new Blob([atob(attachment)], { type: (header.content_type as string) || "application/octet-stream" }),
+    );
+    const downloadName = `${name}.bin`;
+    content = (
+      <a href={downloadUrl} download={downloadName}>
+        Download
+      </a>
+    );
   }
 
   return (

--- a/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
@@ -1,20 +1,24 @@
 import type { EnvelopeItem } from "@sentry/core";
+import JsonViewer from "../../shared/JsonViewer";
+import type { ReactNode } from "react";
 
 export default function Attachment({ header, attachment }: { header: EnvelopeItem[0]; attachment: string }) {
-  let text: string | null = null;
+  let content: ReactNode | null = null;
+  const name = (header.filename as string) || "<unknown>";
   if (header.content_type === "text/plain") {
-    text = attachment;
+    content = (
+      <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm p-2 bg-primary-900 rounded-sm">
+        {attachment}
+      </pre>
+    );
+  } else if (header.content_type === "application/json") {
+    content = <JsonViewer data={JSON.parse(attachment)} />;
   }
 
-  return text != null ? (
-    <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm p-2 bg-primary-900 rounded-sm">
-      {text}
-    </pre>
-  ) : (
-    <img
-      src={`data:${header.content_type};base64,${attachment}`}
-      alt="Attachment"
-      className="w-full h-full object-contain"
-    />
+  return (
+    <>
+      <h3>📎 {name}</h3>
+      {content}
+    </>
   );
 }

--- a/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/Attachment.tsx
@@ -4,9 +4,6 @@ export default function Attachment({ header, attachment }: { header: EnvelopeIte
   let text: string | null = null;
   if (header.content_type === "text/plain") {
     text = attachment;
-    // @ts-expect-error ts(2367) -- statsd is an old and deprecated event type
-  } else if (header.type! === "statsd") {
-    text = atob(attachment);
   }
 
   return text != null ? (

--- a/packages/overlay/src/telemetry/components/insights/envelopes/EnvelopeDetails.tsx
+++ b/packages/overlay/src/telemetry/components/insights/envelopes/EnvelopeDetails.tsx
@@ -5,6 +5,7 @@ import { useSpotlightContext } from "~/lib/useSpotlightContext";
 import JsonViewer from "~/telemetry/components/shared/JsonViewer";
 import SidePanel, { SidePanelHeader } from "~/ui/sidePanel";
 import Attachment from "./Attachment";
+import { RAW_TYPES } from "@spotlightjs/sidecar/constants";
 
 export default function EnvelopeDetails({ envelope }: { envelope: Envelope }) {
   const [showRawJSON, setShowRawJSON] = useState<boolean>(false);
@@ -64,7 +65,7 @@ export default function EnvelopeDetails({ envelope }: { envelope: Envelope }) {
           <div className="flex flex-col gap-2">
             <h2 className="mb-2 text-xl font-semibold">Items</h2>
             {items.map((item, ind) => {
-              if (item[0].type === "attachment") {
+              if (RAW_TYPES.has(item[0].type)) {
                 // @ts-expect-error -- we are going to fix the types for attachments later
                 const data = item[1].data as string;
                 return <Attachment key={`${ind}-${item[0]?.type}`} header={item[0]} attachment={data} />;

--- a/packages/overlay/src/telemetry/store/slices/envelopesSlice.ts
+++ b/packages/overlay/src/telemetry/store/slices/envelopesSlice.ts
@@ -4,6 +4,7 @@ import { SUPPORTED_EVENT_TYPES } from "../../constants/sentry";
 import type { Sdk, SentryEvent } from "../../types";
 import { sdkToPlatform } from "../../utils/sdkToPlatform";
 import type { EnvelopesSliceActions, EnvelopesSliceState, SentryStore } from "../types";
+import { RAW_TYPES } from "@spotlightjs/sidecar/constants";
 
 const initialEnvelopesState: EnvelopesSliceState = {
   envelopes: new Map(),
@@ -42,7 +43,7 @@ export const createEnvelopesSlice: StateCreator<SentryStore, [], [], EnvelopesSl
     for (const [itemHeader, itemData] of items) {
       if (SUPPORTED_EVENT_TYPES.has(itemHeader.type)) {
         const item = itemData as SentryEvent;
-        if (itemHeader.type !== "attachment") {
+        if (!RAW_TYPES.has(itemHeader.type)) {
           item.platform = sdkToPlatform(sdk.name);
         }
         if (traceContext) {

--- a/packages/overlay/src/telemetry/store/slices/envelopesSlice.ts
+++ b/packages/overlay/src/telemetry/store/slices/envelopesSlice.ts
@@ -42,7 +42,9 @@ export const createEnvelopesSlice: StateCreator<SentryStore, [], [], EnvelopesSl
     for (const [itemHeader, itemData] of items) {
       if (SUPPORTED_EVENT_TYPES.has(itemHeader.type)) {
         const item = itemData as SentryEvent;
-        item.platform = sdkToPlatform(sdk.name);
+        if (itemHeader.type !== "attachment") {
+          item.platform = sdkToPlatform(sdk.name);
+        }
         if (traceContext) {
           if (!item.contexts) {
             item.contexts = {};

--- a/packages/sidecar/src/constants.ts
+++ b/packages/sidecar/src/constants.ts
@@ -1,3 +1,4 @@
 export const DEFAULT_PORT = 8969;
 export const SERVER_IDENTIFIER = "spotlight-by-sentry";
 export const CONTEXT_LINES_ENDPOINT = "/contextlines";
+export const RAW_TYPES = new Set(["attachment", "replay_video", "statsd"]);

--- a/packages/sidecar/src/parser/processEnvelope.ts
+++ b/packages/sidecar/src/parser/processEnvelope.ts
@@ -9,6 +9,8 @@ export type ParsedEnvelope = {
   rawEvent: RawEventContext;
 };
 
+const TEXT_CONTENT_TYPES = new Set(["text/plain", "application/json"]);
+
 /**
  * Implements parser for
  * @see https://develop.sentry.dev/sdk/envelopes/#serialization-format
@@ -49,14 +51,13 @@ export function processEnvelope(rawEvent: RawEventContext): ParsedEnvelope {
           itemHeader.content_type = "text/plain";
         }
         itemPayload = {
-          data: rawPayload.toString(itemHeader.content_type === "text/plain" ? "utf-8" : "base64"),
+          data: rawPayload.toString(TEXT_CONTENT_TYPES.has(itemHeader.content_type as string) ? "utf-8" : "base64"),
         };
       } else {
         itemPayload = parseJSONFromBuffer(itemPayloadRaw);
         if (!itemPayload) {
           logger.error(itemHeader);
-        }
-        if (itemHeader.type && itemPayload) {
+        } else if (itemHeader.type) {
           // data sanitization
           // @ts-expect-error ts(2339) -- We should really stop adding type to payloads
           itemPayload.type = itemHeader.type;

--- a/packages/sidecar/src/parser/processEnvelope.ts
+++ b/packages/sidecar/src/parser/processEnvelope.ts
@@ -17,7 +17,7 @@ const TEXT_CONTENT_TYPES = new Set(["text/plain", "application/json"]);
  * @param rawEvent Envelope data
  * @returns parsed envelope
  */
-export function processEnvelope(rawEvent: RawEventContext): ParsedEnvelope {
+export function processEnvelope(rawEvent: RawEventContext): ParsedEnvelope | null {
   let buffer = typeof rawEvent.data === "string" ? Uint8Array.from(rawEvent.data, c => c.charCodeAt(0)) : rawEvent.data;
 
   function readLine(length?: number) {
@@ -28,6 +28,10 @@ export function processEnvelope(rawEvent: RawEventContext): ParsedEnvelope {
   }
 
   const envelopeHeader = parseJSONFromBuffer(readLine()) as Envelope[0];
+  if (!envelopeHeader) {
+    logger.error("Malformed envelope header, skipping...");
+    return null;
+  }
 
   const envelopeId = uuidv7();
   envelopeHeader.__spotlight_envelope_id = envelopeId;


### PR DESCRIPTION
Supresses parsing errors for statsd and replay_video event types and displays statsd data as text.
