### PR TITLE
fix(website): Fix 'add to cursor' link

### DIFF
--- a/packages/website/src/components/MCPHero.astro
+++ b/packages/website/src/components/MCPHero.astro
@@ -184,7 +184,7 @@
 <div class="hero-container">
   <div class="command-box">
     <a
-      href="cursor://anysphere.cursor-deeplink/mcp/install?name=Sentry%20Spotlight&config=eyJjb21tYW5kIjoibnB4IC15IEBzcG90bGlnaHRqcy9zcG90bGlnaHQgLS1zdGRpbi1tY3AifQ%3D%3D"
+      href="cursor://anysphere.cursor-deeplink/mcp/install?name=Sentry%20Spotlight&config=eyJjb21tYW5kIjoibnB4IC15IEBzcG90bGlnaHRqcy9zcG90bGlnaHQgLS1zdGRpby1tY3AifQ=="
       ><img
         src="https://cursor.com/deeplink/mcp-install-dark.svg"
         alt="Add Sentry Spotlight MCP server to Cursor"


### PR DESCRIPTION
Hat tip to @codyde for the fix -- the arg should have been `--stdio-mcp` and it was `--stdin-mcp` before the patch
