### PR TITLE
fix(website) claude code copy was multiline, errroing in terminal

### DIFF
--- a/packages/website/src/components/MCPHero.astro
+++ b/packages/website/src/components/MCPHero.astro
@@ -194,10 +194,7 @@
   </div>
   <div class="command-box">
     <span class="terminal-prompt">$</span>
-    <span class="command-text"
-      >claude mcp add sentry-spotlight -- npx -y @spotlightjs/spotlight
-      --stdio-mcp</span
-    >
+    <span class="command-text">claude mcp add sentry-spotlight -- npx -y @spotlightjs/spotlight --stdio-mcp</span>
     <button class="copy-button" type="button">Copy</button>
   </div>
   <img


### PR DESCRIPTION
Before
```
claude mcp add sentry-spotlight -- npx -y @spotlightjs/spotlight
      --stdio-mcp
```

After
```
claude mcp add sentry-spotlight -- npx -y @spotlightjs/spotlight --stdio-mcp
```

