### PR TITLE
fix: Drop min Node version to v20

### DIFF
--- a/.changeset/violet-eggs-draw.md
+++ b/.changeset/violet-eggs-draw.md
@@ -1,0 +1,6 @@
+---
+"@spotlightjs/spotlight": patch
+"@spotlightjs/sidecar": patch
+---
+
+Drop min Node version requirement to v20 again

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node_version: [22, 24]
+        node_version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -189,7 +189,7 @@ jobs:
     container: mcr.microsoft.com/playwright:v${{needs.build.outputs.playwright-version}}-noble
     strategy:
       matrix:
-        node_version: [22, 24]
+        node_version: [20, 22, 24]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "packageManager": "pnpm@9.15.9",
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   },
   "volta": {
     "node": "22.11.0",

--- a/packages/sidecar/package.json
+++ b/packages/sidecar/package.json
@@ -64,6 +64,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   }
 }

--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -129,7 +129,12 @@ async function startServer(options: StartServerOptions): Promise<ServerType> {
     app.get("/*", serveFilesHandler(filesToServe));
   }
 
-  const { resolve, reject, promise } = Promise.withResolvers<ServerType>();
+  let resolve: (value: ServerType) => void;
+  let reject: (err: Error) => void;
+  const promise = new Promise<ServerType>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
   const sidecarServer = serve(
     {
       fetch: app.fetch,

--- a/packages/sidecar/tsconfig.json
+++ b/packages/sidecar/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "@spotlightjs/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "lib": ["ES2024"],
+    "lib": ["ES2023"],
     "baseUrl": ".",
     "paths": {
       "~/*": ["src/*"]

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -49,6 +49,6 @@
     "extends": "../../package.json"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=20"
   }
 }


### PR DESCRIPTION
Turns out there are still a bunch of folks and apps use Node v20 by default and we don't provide a meaningful error when we fail on Node v20. We only needed this for `Promise.withResolvers()` which is trivial to polyfill hence reverting.

Fixes #940 for sure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Lowers Node engine to >=20 across packages, adds Node 20 to CI matrices, downgrades TS lib to ES2023, and replaces Promise.withResolvers with a manual Promise in sidecar.
> 
> - **Engines/Compatibility**:
>   - Set `"engines.node"` to `>=20` in `package.json`, `packages/spotlight/package.json`, and `packages/sidecar/package.json`.
>   - Downgrade TS lib target from `ES2024` to `ES2023` in `packages/sidecar/tsconfig.json`.
> - **CI**:
>   - Add Node `20` to test matrices in `.github/workflows/build.yml` for unit and e2e jobs (`[20, 22, 24]`).
> - **Sidecar**:
>   - Replace `Promise.withResolvers()` with manual `new Promise` resolve/reject in `src/main.ts` for Node 20 compatibility.
> - **Release**:
>   - Add changeset for patch releases of `@spotlightjs/spotlight` and `@spotlightjs/sidecar`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 776f9f97068e0524a437c020042d4e73d132282b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->