### PR TITLE
fix(overlay): add historyApiFallback to Vite dev server

### DIFF
--- a/packages/overlay/vite.dev.config.ts
+++ b/packages/overlay/vite.dev.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
     headers: {
       "Document-Policy": "js-profiling",
     },
+    historyApiFallback: true,
   },
   build: {
     outDir: resolve(__dirname, "dist", "overlay"),


### PR DESCRIPTION
## Summary
This PR fixes 404 errors when hard refreshing on client-side routes in the overlay dev server by adding `historyApiFallback: true` to the Vite dev server configuration.

## Problem
When navigating to routes like `/telemetry` in the overlay and then hard refreshing the page, users would encounter a 404 error. This happens because:

1. The overlay uses React Router for client-side routing
2. On hard refresh, the browser makes a server request for the specific path (e.g., `/telemetry`)
3. The Vite dev server doesn't know about this route and returns a 404

## Solution
Added `historyApiFallback: true` to the Vite dev server configuration in `packages/overlay/vite.dev.config.ts`. This tells the dev server to serve `index.html` for any route that doesn't correspond to an actual file, allowing React Router to handle the client-side routing properly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enable SPA fallback by adding `historyApiFallback: true` to `packages/overlay/vite.dev.config.ts` so client-side routes load on refresh during development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9bd3397426d6467e81789d575349c123a690875. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->