### PR TITLE
feat: added more filters in the MCP tools

### DIFF
--- a/packages/sidecar/src/mcp/mcp.ts
+++ b/packages/sidecar/src/mcp/mcp.ts
@@ -20,7 +20,7 @@ const inputSchema = {
       "Look back this many seconds for errors. Use 300+ for broader investigation. Use 30 for recent errors only. For debugging, use 10. For most cases, use 60.",
     ),
   search: z.string().optional().describe("Search envelopes by content. (e.g. filename, error message, etc.)"),
-  filename: z.string().optional().describe("Search envelopes by filename."),
+  filename: z.string().optional().describe("Search events by filename."),
   pagination: z
     .object({
       limit: z.number().describe("Get the last n events."),

--- a/packages/sidecar/src/mcp/mcp.ts
+++ b/packages/sidecar/src/mcp/mcp.ts
@@ -13,13 +13,18 @@ import { getBuffer } from "~/utils/index.js";
 import { NO_ERRORS_CONTENT, NO_LOGS_CONTENT } from "./constants.js";
 
 const inputSchema = {
-  timeWindow: z
-    .number()
-    .optional()
-    .describe(
-      "Look back this many seconds for errors. Use 300+ for broader investigation and something around 60 for everything else",
-    ),
-  filename: z.string().optional().describe("Search events by filename."),
+  filters: z.union([
+    z.object({
+      timeWindow: z
+        .number()
+        .describe(
+          "Look back this many seconds for errors. Use 300+ for broader investigation and something around 60 for everything else",
+        ),
+    }),
+    z.object({
+      filename: z.string().describe("Search events by filename."),
+    }),
+  ]),
   /**
    * TODO: Need to check, if this approach is better then a cursor based approach,
    * where the user can pass `events since [event_id]` as "last N events" is a
@@ -115,7 +120,7 @@ User: "App crashes after deployment"
       inputSchema,
     },
     async args => {
-      const { pagination, ...filters } = args;
+      const { pagination, filters } = args;
       const envelopes = getBuffer().read(filters);
 
       if (envelopes.length === 0) {
@@ -222,7 +227,7 @@ User: "I added logging to track user actions"
       inputSchema,
     },
     async args => {
-      const { pagination, ...filters } = args;
+      const { pagination, filters } = args;
       const envelopes = getBuffer().read(filters);
 
       if (envelopes.length === 0) {
@@ -286,7 +291,7 @@ After identifying a trace of interest, use \`get_events_for_trace\` with the tra
       inputSchema,
     },
     async args => {
-      const { pagination, ...filters } = args;
+      const { pagination, filters } = args;
       const envelopes = getBuffer().read(filters);
 
       if (envelopes.length === 0) {

--- a/packages/sidecar/src/mcp/mcp.ts
+++ b/packages/sidecar/src/mcp/mcp.ts
@@ -304,7 +304,7 @@ After identifying a trace of interest, use \`get_events_for_trace\` with the tra
         };
       }
 
-      const content: TextContent[] = [];
+      let content: TextContent[] = [];
 
       // Sort traces by start time (most recent first)
       const sortedTraces = Array.from(traces.values()).sort(
@@ -324,12 +324,14 @@ After identifying a trace of interest, use \`get_events_for_trace\` with the tra
         });
       }
 
+      content = applyPagination(content, args.pagination);
+
       content.push({
         type: "text",
         text: "\n**Next Steps:**\nUse `get_events_for_trace` with a trace ID (e.g., first 8 characters shown above) to see the full span tree and detailed timing breakdown for any specific trace.",
       });
 
-      return { content: applyPagination(content, args.pagination) };
+      return { content };
     },
   );
 

--- a/packages/sidecar/src/mcp/mcp.ts
+++ b/packages/sidecar/src/mcp/mcp.ts
@@ -13,13 +13,20 @@ import { getBuffer } from "~/utils/index.js";
 import { NO_ERRORS_CONTENT, NO_LOGS_CONTENT } from "./constants.js";
 
 const inputSchema = {
-  duration: z
+  timeWindow: z
     .number()
     .optional()
     .describe(
-      "Look back this many seconds for errors. Use 300+ for broader investigation and something around 60 for most other stuff",
+      "Look back this many seconds for errors. Use 300+ for broader investigation and something around 60 for everything else",
     ),
   filename: z.string().optional().describe("Search events by filename."),
+  /**
+   * TODO: Need to check, if this approach is better then a cursor based approach,
+   * where the user can pass `events since [event_id]` as "last N events" is a
+   * moving target as events keep coming in.
+   *
+   * https://github.com/getsentry/spotlight/pull/968#discussion_r2391587907
+   */
   pagination: z
     .object({
       limit: z.number().describe("Get the last n events."),

--- a/packages/sidecar/src/mcp/mcp.ts
+++ b/packages/sidecar/src/mcp/mcp.ts
@@ -17,9 +17,8 @@ const inputSchema = {
     .number()
     .optional()
     .describe(
-      "Look back this many seconds for errors. Use 300+ for broader investigation. Use 30 for recent errors only. For debugging, use 10. For most cases, use 60.",
+      "Look back this many seconds for errors. Use 300+ for broader investigation and something around 60 for most other stuff",
     ),
-  search: z.string().optional().describe("Search envelopes by content. (e.g. filename, error message, etc.)"),
   filename: z.string().optional().describe("Search events by filename."),
   pagination: z
     .object({
@@ -109,7 +108,8 @@ User: "App crashes after deployment"
       inputSchema,
     },
     async args => {
-      const envelopes = getBuffer().read(args);
+      const { pagination, ...filters } = args;
+      const envelopes = getBuffer().read(filters);
 
       if (envelopes.length === 0) {
         return NO_ERRORS_CONTENT;
@@ -138,7 +138,7 @@ User: "App crashes after deployment"
       }
 
       return {
-        content: applyPagination(content, args.pagination),
+        content: applyPagination(content, pagination),
       };
     },
   );
@@ -215,7 +215,8 @@ User: "I added logging to track user actions"
       inputSchema,
     },
     async args => {
-      const envelopes = getBuffer().read(args);
+      const { pagination, ...filters } = args;
+      const envelopes = getBuffer().read(filters);
 
       if (envelopes.length === 0) {
         return NO_LOGS_CONTENT;
@@ -244,7 +245,7 @@ User: "I added logging to track user actions"
       }
 
       return {
-        content: applyPagination(content, args.pagination),
+        content: applyPagination(content, pagination),
       };
     },
   );
@@ -278,7 +279,8 @@ After identifying a trace of interest, use \`get_events_for_trace\` with the tra
       inputSchema,
     },
     async args => {
-      const envelopes = getBuffer().read(args);
+      const { pagination, ...filters } = args;
+      const envelopes = getBuffer().read(filters);
 
       if (envelopes.length === 0) {
         return {
@@ -324,7 +326,7 @@ After identifying a trace of interest, use \`get_events_for_trace\` with the tra
         });
       }
 
-      content = applyPagination(content, args.pagination);
+      content = applyPagination(content, pagination);
 
       content.push({
         type: "text",
@@ -371,7 +373,7 @@ get_events_for_trace(traceId: "71a8c5e41ae1044dee67f50a07538fe7")  // Using full
     },
     async args => {
       // Getting all the envelopes
-      const envelopes = getBuffer().read();
+      const envelopes = getBuffer().read({});
       const traces = extractTracesFromEnvelopes(envelopes);
 
       // Find trace by full ID or partial ID match

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -113,13 +113,13 @@ export class MessageBuffer<T> {
     this.head = this.writePos;
   }
 
-  read(filters: ReadFilter = { duration: 60 }): T[] {
+  read(filters: ReadFilter = { timeWindow: 60 }): T[] {
     const result: T[] = [];
     const start = this.head;
     const end = this.writePos;
 
     const filterHandlers = [];
-    for (const key in Object.keys(filters)) {
+    for (const key of Object.keys(filters)) {
       if (this.filterHandlers[key]) {
         filterHandlers.push(this.filterHandlers[key]);
       }
@@ -140,12 +140,12 @@ export class MessageBuffer<T> {
   }
 
   filterHandlers: Record<keyof ReadFilter | string, (item: [number, T], value: ReadFilter) => boolean> = {
-    duration: (item, value) => {
-      if (value.duration == null) {
+    timeWindow: (item, value) => {
+      if (value.timeWindow == null) {
         return true;
       }
 
-      return item[0] > Date.now() - value.duration * 1000;
+      return item[0] > Date.now() - value.timeWindow * 1000;
     },
     envelopeId: (item, value) => {
       if (value.envelopeId == null) {

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -168,11 +168,12 @@ export class MessageBuffer<T> {
       return JSON.stringify(data.event).includes(value.search);
     },
     filename: (item, value) => {
-      if (value.filename == null) {
+      const { filename } = value;
+      if (filename == null) {
         return true;
       }
 
-      const filename = value.filename;
+
       const contents = (item[1] as EventContainer).getParsedEnvelope();
 
       for (const [, payload] of contents.event[1]) {

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -134,8 +134,6 @@ export class MessageBuffer<T> {
       if (filterHandlers.every(handler => handler(item, filters))) {
         result.push(item[1]);
       }
-
-      result.push(item[1]);
     }
 
     return result;
@@ -174,6 +172,7 @@ export class MessageBuffer<T> {
           ),
       );
     },
+    all: () => true,
   };
 }
 

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -1,5 +1,5 @@
 import { uuidv7 } from "uuidv7";
-import type { FilterSchema } from "./mcp/mcp.js";
+import type { InputSchema } from "./mcp/mcp.js";
 import type { EventContainer } from "./utils/eventContainer.js";
 
 export class MessageBuffer<T> {
@@ -192,6 +192,6 @@ export class MessageBuffer<T> {
   };
 }
 
-export type ReadFilter = FilterSchema & {
+export type ReadFilter = InputSchema & {
   envelopeId?: string;
 };

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -176,6 +176,6 @@ export class MessageBuffer<T> {
   };
 }
 
-export type ReadFilter = Omit<InputSchema, "pagination"> & {
+export type ReadFilter = InputSchema["filters"] & {
   envelopeId?: string;
 };

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -131,7 +131,9 @@ export class MessageBuffer<T> {
       if (item == null) continue;
 
       // Check if the item passes all filters
-      if (!filterHandlers.every(handler => handler(item, filters))) continue;
+      if (filterHandlers.every(handler => handler(item, filters))) {
+        result.push(item[1]);
+      }
 
       result.push(item[1]);
     }

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -192,6 +192,6 @@ export class MessageBuffer<T> {
   };
 }
 
-export type ReadFilter = InputSchema & {
+export type ReadFilter = Omit<InputSchema, "pagination"> & {
   envelopeId?: string;
 };

--- a/packages/sidecar/src/messageBuffer.ts
+++ b/packages/sidecar/src/messageBuffer.ts
@@ -112,27 +112,27 @@ export class MessageBuffer<T> {
     this.head = this.writePos;
   }
 
-  read(filters: ReadFilter): T[] {
+  read(filters?: ReadFilter): T[] {
     const result: T[] = [];
+    const start = this.head;
+    const end = this.writePos;
 
-    const filterHandlers = Object.keys(filters)
+    const filterHandlers = Object.keys(filters ?? {})
       .map(key => this.filterHandlers[key])
       .filter(Boolean);
-
-    const { limit, offset = 0 } = filters.pagination ?? {};
-    const end = this.writePos - offset;
-    const start = limit ? end - limit : this.head;
 
     for (let i = end - 1; i >= start; i--) {
       const item = this.items[i % this.size];
 
       if (item === undefined) continue;
 
-      // Apply all filters
-      const isValid = filterHandlers.every(handler => handler(item, filters));
+      if (filters != null) {
+        // Apply all filters
+        const isValid = filterHandlers.every(handler => handler(item, filters));
 
-      // Check if the item passes all filters
-      if (!isValid) continue;
+        // Check if the item passes all filters
+        if (!isValid) continue;
+      }
 
       result.push(item[1]);
     }
@@ -175,9 +175,4 @@ export type ReadFilter = {
   envelopeId?: string;
   // Search by filename
   filename?: string;
-  // Get events based on a limit and offset.
-  pagination?: {
-    limit: number;
-    offset: number;
-  };
 };

--- a/packages/sidecar/src/routes/__tests__/server.test.ts
+++ b/packages/sidecar/src/routes/__tests__/server.test.ts
@@ -105,7 +105,9 @@ describe("mcp", () => {
         params: {
           name: "get_local_errors",
           arguments: {
-            duration: 60,
+            filters: {
+              timeWindow: 60,
+            },
           },
         },
       }),
@@ -155,7 +157,9 @@ describe("mcp", () => {
         params: {
           name: "get_local_errors",
           arguments: {
-            duration: 60,
+            filters: {
+              timeWindow: 60,
+            },
           },
         },
       }),


### PR DESCRIPTION
Possible fix for #967 

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Unifies tool input with duration/filename/pagination, applies pagination to outputs, extends MessageBuffer with filename filtering and default duration, and adjusts trace/event reading behavior.
> 
> - **MCP Tools**:
>   - **Unified input**: Replace `timeWindow` with shared `inputSchema` (`duration`, `filename`, `pagination`).
>   - **Filtering/Pagination**: Use buffer `read(filters)` and paginate `content` in `get_local_errors`, `get_local_logs`, and `get_local_traces`.
>   - **Traces**: Paginate trace summaries before appending guidance.
>   - **Trace Details**: `get_events_for_trace` now reads all envelopes (no fixed 600s window).
> - **MessageBuffer**:
>   - **Read defaults**: `read()` defaults to `duration: 60`.
>   - **New filter**: Add `filename` filter matching stacktrace frame filenames; export `ReadFilter` from `InputSchema` (omit `pagination`).
>   - **Filtering logic**: Refactor to apply registered filter handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c717d19ef08c286cb83d1b7efd4a28d193857d84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->