### PR TITLE
feat: implement Sentry MCP Instrucmentation for the Spotlight MCP

### DIFF
--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -13,7 +13,6 @@ Sentry.init({
       blockAllMedia: true,
     }),
   ],
-  sendDefaultPii: true,
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
   replaysSessionSampleRate: 1.1,

--- a/packages/electron/src/index.ts
+++ b/packages/electron/src/index.ts
@@ -13,6 +13,7 @@ Sentry.init({
       blockAllMedia: true,
     }),
   ],
+  sendDefaultPii: true,
   tracesSampleRate: 1.0,
   profilesSampleRate: 1.0,
   replaysSessionSampleRate: 1.1,

--- a/packages/sidecar/src/mcp/mcp.ts
+++ b/packages/sidecar/src/mcp/mcp.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { TextContent } from "@modelcontextprotocol/sdk/types.js";
+import { wrapMcpServerWithSentry } from "@sentry/node";
 import { z } from "zod";
 import {
   buildSpanTree,
@@ -13,10 +14,12 @@ import { getBuffer } from "~/utils/index.js";
 import { NO_ERRORS_CONTENT, NO_LOGS_CONTENT } from "./constants.js";
 
 export function createMCPInstance() {
-  const mcp = new McpServer({
-    name: "spotlight-mcp",
-    version: String(process.env.npm_package_version),
-  });
+  const mcp = wrapMcpServerWithSentry(
+    new McpServer({
+      name: "spotlight-mcp",
+      version: String(process.env.npm_package_version),
+    }),
+  );
 
   mcp.registerTool(
     "get_local_errors",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Wrap `McpServer` with Sentry using `wrapMcpServerWithSentry` to add instrumentation to the Spotlight MCP.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 863b6358d952078bb30e9551f62c8efb069d8bb4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->