### PR TITLE
fix(overlay): Support AI SDK in our AI view

### DIFF
--- a/packages/overlay/src/telemetry/components/insights/aiTraces/AITraceDetails.tsx
+++ b/packages/overlay/src/telemetry/components/insights/aiTraces/AITraceDetails.tsx
@@ -265,7 +265,7 @@ export function AITraceDetailsEmbedded({ traceId, spanId }: { traceId: string; s
             <span className="text-primary-400 text-sm">{aiTrace.id}</span>
           </div>
           <div className="flex items-center gap-2">
-            <Badge color="primary">{handler.getTypeBadge(aiTrace)}</Badge>
+            <Badge color={aiTrace.hasToolCall ? "warning" : "primary"}>{handler.getTypeBadge(aiTrace)}</Badge>
             {aiTrace.metadata.modelId && <Badge color="secondary">{aiTrace.metadata.modelId}</Badge>}
             {aiTrace.metadata.functionId && <Badge color="neutral">{aiTrace.metadata.functionId}</Badge>}
           </div>

--- a/packages/overlay/src/telemetry/components/insights/aiTraces/AITraceDetails.tsx
+++ b/packages/overlay/src/telemetry/components/insights/aiTraces/AITraceDetails.tsx
@@ -3,6 +3,7 @@ import { useParams } from "react-router-dom";
 import {
   createAITraceFromSpan,
   detectAILibraryHandler,
+  extractAllAIRootSpans,
 } from "~/telemetry/components/insights/aiTraces/sdks/aiLibraries";
 import type { AILibraryHandler, SpotlightAITrace } from "~/telemetry/types";
 import { getFormattedDuration } from "~/telemetry/utils/duration";
@@ -215,7 +216,9 @@ function ToolCallsSection({ trace }: { trace: SpotlightAITrace }) {
 // embedded version for split view
 export function AITraceDetailsEmbedded({ traceId, spanId }: { traceId: string; spanId: string }) {
   const trace = useSentryStore(state => state.getTraceById)(traceId);
-  const span = trace?.spans.get(spanId);
+  const span = trace?.spanTree
+    ? extractAllAIRootSpans(trace.spanTree).find(({ span }) => span.span_id === spanId)?.span
+    : null;
   const [spanNodeWidth, setSpanNodeWidth] = useState<number>(50);
 
   if (!trace || !span) {
@@ -265,9 +268,9 @@ export function AITraceDetailsEmbedded({ traceId, spanId }: { traceId: string; s
             <span className="text-primary-400 text-sm">{aiTrace.id}</span>
           </div>
           <div className="flex items-center gap-2">
-            <Badge color={aiTrace.hasToolCall ? "warning" : "primary"}>{handler.getTypeBadge(aiTrace)}</Badge>
-            {aiTrace.metadata.modelId && <Badge color="secondary">{aiTrace.metadata.modelId}</Badge>}
-            {aiTrace.metadata.functionId && <Badge color="neutral">{aiTrace.metadata.functionId}</Badge>}
+            <Badge variant={aiTrace.hasToolCall ? "warning" : "primary"}>{handler.getTypeBadge(aiTrace)}</Badge>
+            {aiTrace.metadata.modelId && <Badge variant="secondary">{aiTrace.metadata.modelId}</Badge>}
+            {aiTrace.metadata.functionId && <Badge variant="neutral">{aiTrace.metadata.functionId}</Badge>}
           </div>
         </div>
 

--- a/packages/overlay/src/ui/badge.tsx
+++ b/packages/overlay/src/ui/badge.tsx
@@ -25,8 +25,8 @@ const badgeVariants = cva(
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, color, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant, color }), className)} {...props} />;
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants };

--- a/packages/overlay/src/ui/badge.tsx
+++ b/packages/overlay/src/ui/badge.tsx
@@ -4,13 +4,17 @@ import type * as React from "react";
 import { cn } from "~/lib/cn";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border border-neutral-200 px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-hidden focus:ring-2 focus:ring-neutral-950 focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium transition-colors focus:outline-hidden focus:ring-2 focus:ring-neutral-950 focus:ring-offset-2",
   {
     variants: {
       variant: {
         default: "border-transparent bg-primary-800 text-neutral-50",
         destructive: "border-transparent bg-red-500 text-neutral-50",
-        outline: "text-neutral-950",
+        outline: "text-neutral-950 border-neutral-200",
+        primary: "border-transparent bg-primary-800 text-neutral-50",
+        secondary: "border-transparent bg-blue-600/30 text-blue-100 border-blue-500/30",
+        neutral: "border-transparent bg-neutral-700 text-neutral-100",
+        warning: "border-transparent bg-orange-600/30 text-orange-100 border-orange-500/30",
       },
     },
     defaultVariants: {
@@ -21,8 +25,8 @@ const badgeVariants = cva(
 
 export interface BadgeProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof badgeVariants> {}
 
-function Badge({ className, variant, ...props }: BadgeProps) {
-  return <div className={cn(badgeVariants({ variant }), className)} {...props} />;
+function Badge({ className, variant, color, ...props }: BadgeProps) {
+  return <div className={cn(badgeVariants({ variant, color }), className)} {...props} />;
 }
 
 export { Badge, badgeVariants };


### PR DESCRIPTION
Closes #966

We supported AI SDK telemetry when they were in beta. Since then, they adopted [opentelemetry gen_ai semantics](https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans/) and our SDKs did that too. 

This PR fixes the compatibility with AI SDK.

Tool call view example: 

<img width="2545" height="1174" alt="Screenshot 2025-10-02 at 14 29 14" src="https://github.com/user-attachments/assets/2c0cd3d9-b969-40dd-a3bd-fb7d7e0e86ed" />
