### PR TITLE
fix(website): Remove footer text

### DIFF
--- a/packages/website/src/components/homepage/Footer.astro
+++ b/packages/website/src/components/homepage/Footer.astro
@@ -61,13 +61,6 @@
       <p class="text-sm text-[#a5a5a5]">
         © 2025 Functional Software, Inc. (d.b.a. Sentry). All rights reserved.
       </p>
-      <div class="flex items-center gap-2 text-sm text-[#a5a5a5] mt-4 md:mt-0">
-        <span>Made with</span>
-        <svg class="w-4 h-4 text-red-400" fill="currentColor" viewBox="0 0 20 20">
-          <path fill-rule="evenodd" d="M3.172 5.172a4 4 0 015.656 0L10 6.343l1.172-1.171a4 4 0 115.656 5.656L10 17.657l-6.828-6.829a4 4 0 010-5.656z" clip-rule="evenodd"/>
-        </svg>
-        <span>by Sentry</span>
-      </div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Removed

>Made with <3 by Sentry

From the footer, as it doesn't really align with Sentry's values.

kudos to @cleptric for the suggestion. 

Gotta find some cool text for it, but until then, removing it.