### PR TITLE
Group cli under tail command

### DIFF
--- a/packages/sidecar/server.ts
+++ b/packages/sidecar/server.ts
@@ -35,7 +35,9 @@ Usage: spotlight-sidecar [command] [options]
 
 Commands:
   tail [types...]      Tail Sentry events (default: everything)
-                       Available types: ${[...SUPPORTED_ARGS].join(", ")}
+                       Available types: ${[...Object.keys(NAME_TO_TYPE_MAPPING)].join(", ")}
+                       Magic words: ${[...EVERYTHING_MAGIC_WORDS].join(", ")}
+  mcp                  Start in MCP (Model Context Protocol) mode
   help                 Show this help message
 
 Options:
@@ -48,6 +50,7 @@ Examples:
   spotlight-sidecar tail               # Tail all event types
   spotlight-sidecar tail errors        # Tail only errors
   spotlight-sidecar tail errors logs   # Tail errors and logs
+  spotlight-sidecar mcp                # Start in MCP mode
   spotlight-sidecar --port 3000        # Start on port 3000
   spotlight-sidecar -p 3000 -d         # Start on port 3000 with debug logging
 `);


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

This PR groups the CLI interface for tailing events under a dedicated `tail` command.

Previously, event types could be passed directly as the first argument (e.g., `spotlight-sidecar errors`). This change introduces a more structured approach:

- All event tailing functionality is now accessed via `spotlight-sidecar tail`.
- Event types are passed as arguments to the `tail` subcommand (e.g., `spotlight-sidecar tail errors` or `spotlight-sidecar tail traces,logs`).
- If no event types are specified with `tail`, it defaults to tailing "everything".

This improves CLI clarity and prepares for future subcommand expansion.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b90fe62-aa2f-44dd-b9df-137ab27d8213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b90fe62-aa2f-44dd-b9df-137ab27d8213"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

