### PR TITLE
fix(spotlight): use actual runtime port in server-timing header for dynamic port assignment

### DIFF
--- a/packages/sidecar/src/main.ts
+++ b/packages/sidecar/src/main.ts
@@ -66,7 +66,7 @@ export async function startServer(options: StartServerOptions): Promise<ServerTy
             [
               `sentryTrace;desc="${traceData["sentry-trace"]}"`,
               `baggage;desc="${traceData.baggage}"`,
-              `sentrySpotlightPort;desc=${options.port}`,
+              `sentrySpotlightPort;desc=${ctx.env.incoming.socket.localPort}`,
             ].join(", "),
           );
 


### PR DESCRIPTION
When using -p 0 for dynamic port assignment, the UI was receiving 0
as the port instead of the actual dynamically assigned port. This fix
changes the sentrySpotlightPort header to use the runtime socket port
(ctx.env.incoming.socket.localPort) instead of the initial options.port
value, ensuring the UI receives the correct port number.
