### PR TITLE
fix(overlay): Fix image preview for resource spans in Electron app

### DIFF
--- a/.changeset/fix-electron-image-preview.md
+++ b/.changeset/fix-electron-image-preview.md
@@ -1,0 +1,6 @@
+---
+"@spotlightjs/overlay": patch
+---
+
+Fix image preview for resource.img spans in Electron app by constructing absolute URLs from relative paths
+

--- a/packages/overlay/src/telemetry/components/insights/Resources.tsx
+++ b/packages/overlay/src/telemetry/components/insights/Resources.tsx
@@ -10,6 +10,7 @@ import useSort from "../../hooks/useSort";
 import type { Span } from "../../types";
 import { formatBytes } from "../../utils/bytes";
 import { getFormattedDuration, getSpanDurationClassName } from "../../utils/duration";
+import { getResourceImageUrl } from "../../utils/resource-url";
 
 type ResourceInfo = {
   avgDuration: number;
@@ -137,18 +138,24 @@ const Resources = () => {
                   <TooltipTrigger asChild>
                     <span className="cursor-default truncate block">{resource.description}</span>
                   </TooltipTrigger>
-                  {resource.similarResources[0].op === "resource.img" && resource.description?.startsWith("/") && (
-                    <TooltipContent side="right" className="border-none bg-transparent p-0 shadow-none">
-                      <div className="bg-primary-800 cursor-pointer rounded-lg p-4 shadow-md">
-                        <h2 className="mb-2 font-bold text-white">Preview</h2>
-                        <img
-                          src={resource.description}
-                          className="inline-block max-h-[150px] max-w-[150px] rounded-sm p-1"
-                          alt="preview"
-                        />
-                      </div>
-                    </TooltipContent>
-                  )}
+                  {(() => {
+                    const imageUrl =
+                      resource.similarResources[0].op === "resource.img"
+                        ? getResourceImageUrl(resource.similarResources[0])
+                        : null;
+                    return imageUrl ? (
+                      <TooltipContent side="right" className="border-none bg-transparent p-0 shadow-none">
+                        <div className="bg-primary-800 cursor-pointer rounded-lg p-4 shadow-md">
+                          <h2 className="mb-2 font-bold text-white">Preview</h2>
+                          <img
+                            src={imageUrl}
+                            className="inline-block max-h-[150px] max-w-[150px] rounded-sm p-1"
+                            alt="preview"
+                          />
+                        </div>
+                      </TooltipContent>
+                    ) : null;
+                  })()}
                 </Tooltip>
               </TooltipProvider>
             </td>

--- a/packages/overlay/src/telemetry/components/traces/spans/SpanDetails.tsx
+++ b/packages/overlay/src/telemetry/components/traces/spans/SpanDetails.tsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { format as formatSQL } from "sql-formatter";
 import JsonViewer from "~/telemetry/components/shared/JsonViewer";
 import { getFormattedDuration } from "~/telemetry/utils/duration";
+import { getResourceImageUrl } from "~/telemetry/utils/resource-url";
 import { isErrorEvent } from "~/telemetry/utils/sentry";
 import { createTab } from "~/telemetry/utils/tabs";
 import { DB_SPAN_REGEX } from "../../../constants";
@@ -41,16 +42,24 @@ function SpanDescription({ span }: { span: Span }) {
   if (span.op && DB_SPAN_REGEX.test(span.op) && span.description) {
     headerText = "Query";
     body = <DBSpanDescription desc={span.description} dbType={span.data?.["db.system"] as string} />;
-  } else if (span.op === "resource.img" && span.description?.indexOf("/") === 0) {
-    headerText = "Preview";
-    body = (
-      <a
-        href={span.description}
-        className="border-primary-950 hover:border-primary-700 -m-2 inline-block max-w-sm cursor-pointer rounded-sm border p-1"
-      >
-        <img src={span.description} alt="preview" style={{ maxHeight: 300 }} />
-      </a>
-    );
+  } else if (span.op === "resource.img") {
+    const imageUrl = getResourceImageUrl(span);
+    if (imageUrl) {
+      headerText = "Preview";
+      body = (
+        <a
+          href={imageUrl}
+          className="border-primary-950 hover:border-primary-700 -m-2 inline-block max-w-sm cursor-pointer rounded-sm border p-1"
+        >
+          <img src={imageUrl} alt="preview" style={{ maxHeight: 300 }} />
+        </a>
+      );
+    } else if (span.description) {
+      headerText = "Description";
+      body = (
+        <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm">{span.description}</pre>
+      );
+    }
   } else if (span.description) {
     headerText = "Description";
     body = <pre className="text-primary-300 whitespace-pre-wrap break-words font-mono text-sm">{span.description}</pre>;

--- a/packages/overlay/src/telemetry/utils/resource-url.ts
+++ b/packages/overlay/src/telemetry/utils/resource-url.ts
@@ -1,0 +1,62 @@
+import type { Span } from "../types";
+
+/**
+ * Constructs an absolute URL for a resource image span.
+ *
+ * This is needed because span.description often contains relative paths (e.g., "/assets/image.png")
+ * which work in browsers but fail in Electron apps running on different ports.
+ *
+ * @param span - The span object containing resource information
+ * @returns Absolute URL string if it can be constructed, null otherwise
+ */
+export function getResourceImageUrl(span: Span): string | null {
+  // Try to get an absolute URL from span data first
+  if (span.data?.url && typeof span.data.url === "string") {
+    try {
+      new URL(span.data.url);
+      return span.data.url;
+    } catch {
+      // Not a valid URL, continue
+    }
+  }
+
+  if (span.data?.["http.url"] && typeof span.data["http.url"] === "string") {
+    try {
+      new URL(span.data["http.url"]);
+      return span.data["http.url"];
+    } catch {
+      // Not a valid URL, continue
+    }
+  }
+
+  // If description is a relative path, try to construct absolute URL
+  if (span.description?.startsWith("/")) {
+    // Try to extract origin from transaction request URL
+    const requestUrl = span.transaction?.request?.url;
+    if (requestUrl && typeof requestUrl === "string") {
+      try {
+        const url = new URL(requestUrl);
+        return `${url.origin}${span.description}`;
+      } catch {
+        // Invalid URL, fall through
+      }
+    }
+
+    // Fallback: if we're in a browser context, use the current origin
+    if (typeof window !== "undefined" && window.location) {
+      return `${window.location.origin}${span.description}`;
+    }
+  }
+
+  // If description is already an absolute URL, return it
+  if (span.description) {
+    try {
+      new URL(span.description);
+      return span.description;
+    } catch {
+      // Not a valid URL
+    }
+  }
+
+  return null;
+}


### PR DESCRIPTION
Fixes #295

## Problem
Image previews for `resource.img` spans don't display in the Electron app because `span.description` contains relative paths (e.g., `/assets/image.png`) which work in browsers but fail in Electron running on port 5317.

## Solution
Created a helper function `getResourceImageUrl` that constructs absolute URLs for resource spans by:
1. First trying to get absolute URLs from `span.data.url` or `span.data['http.url']`
2. For relative paths, constructing absolute URLs using the transaction's request URL origin
3. Falling back to the current window location origin in browser contexts

## Changes
- Created `packages/overlay/src/telemetry/utils/resource-url.ts` with the URL helper function
- Updated `SpanDetails.tsx` to use the helper for image previews
- Updated `Resources.tsx` to use the helper for tooltip previews

This ensures images load correctly in both browser and Electron contexts.