### PR TITLE
fix(electron): Make Sentry error reporting silent for updater failures

### DIFF
--- a/.changeset/brown-ends-win.md
+++ b/.changeset/brown-ends-win.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/electron": patch
+---
+
+Make Sentry error reporting silent for auto-updater failures. Updater check errors are now reported to Sentry in the background without showing disruptive dialogs or error screens to users.

--- a/packages/electron/src/electron/main/index.ts
+++ b/packages/electron/src/electron/main/index.ts
@@ -49,7 +49,10 @@ async function checkForUpdates() {
     await autoUpdater.checkForUpdates();
   } catch (error) {
     console.error(error);
-    Sentry.captureException(error);
+    Sentry.withScope(scope => {
+      scope.setTag("error_source", "updater");
+      Sentry.captureException(error);
+    });
   }
 
   isCheckingForUpdates = false;
@@ -82,7 +85,12 @@ app.on("ready", () => {
     }
   });
 
-  autoUpdater.on("error", error => Sentry.captureException(error));
+  autoUpdater.on("error", error => {
+    Sentry.withScope(scope => {
+      scope.setTag("error_source", "updater");
+      Sentry.captureException(error);
+    });
+  });
 });
 
 Sentry.init({
@@ -444,6 +452,16 @@ const showErrorMessage = () => {
 };
 
 async function askForPermissionToSendToSentry(event: Sentry.Event, hint: Sentry.EventHint) {
+  // Handle updater errors silently - no dialogs or error screens
+  if (event.tags?.error_source === "updater") {
+    // Only send if user has explicitly enabled error reporting
+    if (store.get("sentry-enabled") === false) {
+      return null;
+    }
+    // For updater errors, send silently if enabled or not yet configured
+    return event;
+  }
+
   showErrorMessage();
   if (store.get("sentry-enabled") === false) {
     return null;


### PR DESCRIPTION
## Summary

This PR makes Sentry error reporting silent for auto-updater check failures. Previously, when the updater failed to check for updates, users would see a disruptive dialog asking to send an error report. This was not appropriate for background operations like update checks.

## Changes

- Tagged updater errors with `error_source: 'updater'` tag using `Sentry.withScope`
- Modified `askForPermissionToSendToSentry` to detect updater errors and handle them silently
- Updater errors are now reported to Sentry in the background without showing dialogs or error screens
- Still respects user's error reporting preferences (won't send if explicitly disabled)

## Implementation Details

1. **Error Tagging**: Both locations where updater errors are captured (in `checkForUpdates()` catch block and `autoUpdater.on('error')`) now use `Sentry.withScope` to add an `error_source: 'updater'` tag.

2. **Silent Reporting**: The `beforeSend` hook (`askForPermissionToSendToSentry`) now checks for the updater tag and skips showing the error screen and dialogs while still reporting the error to Sentry if error reporting is enabled or not yet configured.

## Testing

- Updater errors will no longer show user-facing dialogs
- Errors are still logged to console for debugging
- Sentry reporting continues to work for updater errors (when enabled)