### PR TITLE
Resolve merge conflicts and fix ci failure

### DIFF
--- a/.changeset/calm-pears-fix.md
+++ b/.changeset/calm-pears-fix.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/sidecar": patch
+---
+
+Fix breaking error when event type is not supported

--- a/packages/spotlight/src/sidecar/formatters/human/utils.ts
+++ b/packages/spotlight/src/sidecar/formatters/human/utils.ts
@@ -123,8 +123,24 @@ export function inferEnvelopeSource(envelopeHeader: Envelope[0], event?: any): "
 /**
  * Format timestamp as local time HH:MM:SS
  */
-export function formatLocalTime(timestamp?: number): string {
-  const date = timestamp ? new Date(timestamp * 1000) : new Date();
+export function formatLocalTime(timestamp?: number | string): string {
+  let date: Date;
+
+  if (!timestamp) {
+    date = new Date();
+  } else if (typeof timestamp === "string") {
+    // Handle ISO string format (e.g., "2023-11-22T16:23:50.406684Z")
+    date = new Date(timestamp);
+  } else {
+    // Handle Unix timestamp
+    date = new Date(timestamp * 1000);
+  }
+
+  if (Number.isNaN(date.getTime())) {
+    // placeholder with same width as valid timestamp for alignment in the logs
+    return "??:??:??";
+  }
+
   const hours = date.getHours().toString().padStart(2, "0");
   const minutes = date.getMinutes().toString().padStart(2, "0");
   const seconds = date.getSeconds().toString().padStart(2, "0");
@@ -193,7 +209,7 @@ export function colorizeType(type: string): string {
  * Format a complete log line with proper alignment and colors
  */
 export function formatLogLine(
-  timestamp: number | undefined,
+  timestamp: number | string | undefined,
   source: "browser" | "mobile" | "server",
   type: string,
   message: string,

--- a/packages/spotlight/src/sidecar/formatters/index.ts
+++ b/packages/spotlight/src/sidecar/formatters/index.ts
@@ -1,6 +1,30 @@
+import type { Envelope, EnvelopeItem } from "@sentry/core";
+import { logger } from "~/logger.js";
+import type { SentryEvent } from "~/parser/types.js";
+import type { FormatterRegistry } from "./types.js";
+
 export * from "./types.js";
 
 export { formatters as mdFormatters } from "./md/index.js";
 export { formatters as logfmtFormatters } from "./logfmt/index.js";
 export { formatters as jsonFormatters } from "./json/index.js";
 export { formatters as humanFormatters } from "./human/index.js";
+
+/**
+ * Generic function to get a formatter from registry and apply it
+ */
+export function applyFormatter<K extends keyof FormatterRegistry>(
+  registry: FormatterRegistry,
+  eventType: K,
+  payload: EnvelopeItem[1],
+  envelopeHeader: Envelope[0],
+): string[] {
+  const entry = registry[eventType];
+  const event = payload as SentryEvent;
+  if (!entry.typeGuard(event)) {
+    logger.warn(`Skipping event: type guard failed for ${eventType} (event.type=${(event as any).type})`);
+    return [];
+  }
+  // Type assertion needed because TypeScript can't narrow the union type properly
+  return entry.format(event as any, envelopeHeader);
+}

--- a/packages/spotlight/src/sidecar/formatters/types.ts
+++ b/packages/spotlight/src/sidecar/formatters/types.ts
@@ -1,4 +1,4 @@
-import type { Envelope, EnvelopeItem } from "@sentry/core";
+import type { Envelope } from "@sentry/core";
 import type { SentryErrorEvent, SentryEvent, SentryLogEvent, SentryTransactionEvent } from "~/parser/types.js";
 
 /**
@@ -24,24 +24,6 @@ export type FormatterRegistry = {
   log: FormatterEntry<SentryLogEvent>;
   transaction: FormatterEntry<SentryTransactionEvent>;
 };
-
-/**
- * Generic function to get a formatter from registry and apply it
- */
-export function applyFormatter<K extends keyof FormatterRegistry>(
-  registry: FormatterRegistry,
-  eventType: K,
-  payload: EnvelopeItem[1],
-  envelopeHeader: Envelope[0],
-): string[] {
-  const entry = registry[eventType];
-  const event = payload as SentryEvent;
-  if (!entry.typeGuard(event)) {
-    throw new Error(`Formatter received invalid event type: ${(event as any).type}`);
-  }
-  // Type assertion needed because TypeScript can't narrow the union type properly
-  return entry.format(event as any, envelopeHeader);
-}
 
 /**
  * Available formatter types.

--- a/packages/spotlight/src/sidecar/parser/helpers.ts
+++ b/packages/spotlight/src/sidecar/parser/helpers.ts
@@ -18,7 +18,10 @@ export const SUPPORTED_EVENT_TYPES = new Set([
 ]);
 
 export function isErrorEvent(event: SentryEvent): event is SentryErrorEvent {
-  return (!event.type || ERROR_EVENT_TYPES.has(event.type)) && Boolean((event as SentryErrorEvent).exception);
+  const hasValidType = !event.type || ERROR_EVENT_TYPES.has(event.type);
+  const hasException = Boolean((event as SentryErrorEvent).exception);
+  const hasMessage = Boolean((event as SentryErrorEvent).message);
+  return hasValidType && (hasException || hasMessage);
 }
 
 export function isProfileEvent(event: SentryEvent): event is SentryProfileV1Event {

--- a/packages/spotlight/src/sidecar/parser/types.ts
+++ b/packages/spotlight/src/sidecar/parser/types.ts
@@ -126,7 +126,7 @@ export type SentryFormattedMessage =
 
 export type SentryErrorEvent = CommonEventAttrs & {
   type?: "error" | "event" | "message" | "default";
-  exception: EventException;
+  exception?: EventException;
 };
 
 export type Span = {


### PR DESCRIPTION
<!--
Tick these boxes if they're applicable to your PR.
-->

Before opening this PR:

- [x] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

This PR merges the latest `origin/main` to resolve conflicts and addresses a breaking error when event types are not fully supported.

The changes ensure more robust handling of Sentry events by:
- Making the `exception` field optional in `SentryErrorEvent` and updating `isErrorEvent` to correctly identify error events based on `message` when `exception` is absent.
- Modifying `applyFormatter` to log a warning and skip events with failed type guards instead of throwing an error.
- Enhancing `formatLocalTime` to gracefully handle various timestamp formats (Unix, ISO string) and display `??:??:??` for invalid dates, preventing crashes in the log formatter.

---
<a href="https://cursor.com/background-agent?bcId=bc-dee3f04f-a31a-47bf-a1a2-355b62f5bd24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dee3f04f-a31a-47bf-a1a2-355b62f5bd24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

