### PR TITLE
ci: Fix Electron input directory

### DIFF
--- a/packages/spotlight/electron-builder.cjs
+++ b/packages/spotlight/electron-builder.cjs
@@ -47,6 +47,7 @@ builder.build({
       output: "dist-electron",
     },
     files: [
+      "dist-electron/**/*",
       "!**/.vscode/*",
       "!src/*",
       "!scripts/*",


### PR DESCRIPTION
Add `dist-electron` to inclusion files too
