### PR TITLE
feat(cli): Add --open flag to auto-open Spotlight dashboard

### DIFF
--- a/.changeset/cli-open-flag.md
+++ b/.changeset/cli-open-flag.md
@@ -1,0 +1,5 @@
+---
+"@spotlightjs/spotlight": minor
+---
+
+Add `--open` / `-o` CLI flag to automatically open the Spotlight dashboard in your default browser when starting the sidecar

--- a/packages/spotlight/src/server/cli.ts
+++ b/packages/spotlight/src/server/cli.ts
@@ -44,6 +44,11 @@ const PARSE_ARGS_CONFIG = {
       type: "boolean",
       default: false,
     },
+    open: {
+      type: "boolean",
+      short: "o",
+      default: false,
+    },
     help: {
       type: "boolean",
       short: "h",
@@ -58,6 +63,7 @@ export type CLIArgs = {
   port: number;
   debug: boolean;
   help: boolean;
+  open: boolean;
   format: FormatterType;
   cmd: string | undefined;
   cmdArgs: string[];
@@ -117,6 +123,7 @@ export function parseCLIArgs(): CLIArgs {
   const result: CLIArgs = {
     debug: values.debug as boolean,
     help: values.help as boolean,
+    open: values.open as boolean,
     format: format as FormatterType,
     port,
     cmd: positionals[0],
@@ -139,7 +146,7 @@ export async function main({
   basePath,
   filesToServe,
 }: { basePath?: CLIHandlerOptions["basePath"]; filesToServe?: CLIHandlerOptions["filesToServe"] } = {}) {
-  let { cmd, cmdArgs, help, port, debug, format, allowedOrigins } = parseCLIArgs();
+  let { cmd, cmdArgs, help, port, debug, format, allowedOrigins, open } = parseCLIArgs();
   if (debug || process.env.SPOTLIGHT_DEBUG) {
     enableDebugLogging(true);
   }
@@ -161,5 +168,5 @@ export async function main({
 
   const handler = CLI_CMD_MAP.get(cmd) || showHelp;
 
-  return await handler({ cmd, cmdArgs, port, help, debug, format, basePath, filesToServe, allowedOrigins });
+  return await handler({ cmd, cmdArgs, port, help, debug, format, basePath, filesToServe, allowedOrigins, open });
 }

--- a/packages/spotlight/src/server/cli/help.ts
+++ b/packages/spotlight/src/server/cli/help.ts
@@ -16,6 +16,7 @@ Commands:
 
 Options:
   -p, --port <port>      Port to listen on (default: 8969, or 0 for random)
+  -o, --open             Open the Spotlight dashboard in your default browser
   -d, --debug            Enable debug logging
   -f, --format <format>  Output format for tail command (default: human)
                          Available formats: ${[...AVAILABLE_FORMATTERS].join(", ")}
@@ -29,6 +30,7 @@ Options:
 
 Examples:
   spotlight                          # Start on default port 8969
+  spotlight --open                   # Start and open dashboard in browser
   spotlight tail                     # Tail all event types (human format)
   spotlight tail errors              # Tail only errors
   spotlight tail errors logs         # Tail errors and logs

--- a/packages/spotlight/src/server/cli/run.ts
+++ b/packages/spotlight/src/server/cli/run.ts
@@ -12,7 +12,7 @@ import { logger } from "../logger.ts";
 import type { SentryLogEvent } from "../parser/types.ts";
 import type { CLIHandlerOptions } from "../types/cli.ts";
 import { buildDockerComposeCommand, detectDockerCompose } from "../utils/docker-compose.ts";
-import { getSpotlightURL } from "../utils/extras.ts";
+import { getSpotlightURL, openInBrowser } from "../utils/extras.ts";
 import { EventContainer, getBuffer } from "../utils/index.ts";
 import tail, { type OnItemCallback } from "./tail.ts";
 
@@ -115,6 +115,7 @@ export default async function run({
   filesToServe,
   format,
   allowedOrigins,
+  open,
 }: CLIHandlerOptions) {
   let relayStdioAsLogs = true;
 
@@ -167,6 +168,10 @@ export default async function run({
   // or started in a weird manner (like over a unix socket)
   const actualServerPort = (serverInstance.address() as AddressInfo).port;
   const spotlightUrl = getSpotlightURL(actualServerPort, LOCALHOST_HOST);
+
+  if (open) {
+    openInBrowser(actualServerPort);
+  }
   let shell = false;
   let stdin: string | undefined = undefined;
   const env = {

--- a/packages/spotlight/src/server/cli/server.ts
+++ b/packages/spotlight/src/server/cli/server.ts
@@ -1,12 +1,23 @@
+import type { AddressInfo } from "node:net";
 import { setupSpotlight } from "../main.ts";
 import type { CLIHandlerOptions } from "../types/cli.ts";
+import { openInBrowser } from "../utils/extras.ts";
 
-export default async function server({ port, basePath, filesToServe, allowedOrigins }: CLIHandlerOptions) {
-  return await setupSpotlight({
+export default async function server({ port, basePath, filesToServe, allowedOrigins, open }: CLIHandlerOptions) {
+  const serverInstance = await setupSpotlight({
     port,
     basePath,
     filesToServe,
     isStandalone: true,
     allowedOrigins,
   });
+
+  if (open) {
+    // Use actual port from server instance, or fall back to requested port
+    // (when serverInstance is undefined, a server is already running on the requested port)
+    const actualPort = serverInstance ? (serverInstance.address() as AddressInfo).port : port;
+    openInBrowser(actualPort);
+  }
+
+  return serverInstance;
 }

--- a/packages/spotlight/src/server/types/cli.ts
+++ b/packages/spotlight/src/server/types/cli.ts
@@ -7,6 +7,7 @@ export type CLIHandlerOptions = {
   port: SideCarOptions["port"];
   help?: boolean;
   debug?: boolean;
+  open?: boolean;
   format?: FormatterType;
   basePath?: SideCarOptions["basePath"];
   filesToServe?: SideCarOptions["filesToServe"];

--- a/packages/spotlight/tests/e2e/cli/run.e2e.test.ts
+++ b/packages/spotlight/tests/e2e/cli/run.e2e.test.ts
@@ -220,4 +220,29 @@ describe("spotlight run e2e tests", () => {
     const stderr = run.stderr.join("");
     expect(stderr).toMatch(/exited/);
   }, 20000);
+
+  it("should accept --open flag without error", async () => {
+    const run = spawnSpotlight(["run", "--open", "node", "-e", 'console.log("test"); process.exit(0)']);
+    activeProcesses.push(run);
+
+    // Wait for the run command to detect child exit
+    await waitForOutput(run, /exited/, 15000, "stderr");
+
+    // Verify we got exit message in stderr (not an error about unknown flag)
+    const stderr = run.stderr.join("");
+    expect(stderr).toMatch(/exited/);
+    expect(stderr).not.toMatch(/unknown.*option.*open/i);
+  }, 20000);
+
+  it("should accept -o short flag without error", async () => {
+    const run = spawnSpotlight(["run", "-o", "node", "-e", 'console.log("test"); process.exit(0)']);
+    activeProcesses.push(run);
+
+    // Wait for the run command to detect child exit
+    await waitForOutput(run, /exited/, 15000, "stderr");
+
+    // Verify we got exit message in stderr
+    const stderr = run.stderr.join("");
+    expect(stderr).toMatch(/exited/);
+  }, 20000);
 });

--- a/packages/spotlight/tests/e2e/cli/server.e2e.test.ts
+++ b/packages/spotlight/tests/e2e/cli/server.e2e.test.ts
@@ -1,0 +1,84 @@
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { ensureSpotlightBuilt, findFreePort } from "../shared/utils";
+import type { SpawnResult } from "../shared/utils";
+import { killGracefully, spawnSpotlight, waitForSidecarReady } from "./helpers";
+
+describe("spotlight server e2e tests", () => {
+  const activeProcesses: SpawnResult[] = [];
+
+  beforeAll(async () => {
+    await ensureSpotlightBuilt();
+  });
+
+  afterEach(async () => {
+    // Clean up all spawned processes
+    for (const proc of activeProcesses) {
+      if (proc.process.pid && !proc.process.killed) {
+        await killGracefully(proc.process).catch(() => {
+          // Force kill if graceful shutdown fails
+          proc.process.kill("SIGKILL");
+        });
+      }
+    }
+    activeProcesses.length = 0;
+  });
+
+  it("should start server on default port", async () => {
+    const port = await findFreePort();
+
+    const server = spawnSpotlight(["server", "-p", port.toString()]);
+    activeProcesses.push(server);
+
+    await waitForSidecarReady(port, 10000);
+
+    // Server should be running - we can verify by checking stderr for listening message
+    const stderr = server.stderr.join("");
+    expect(stderr).toMatch(/listening/i);
+  }, 15000);
+
+  it("should accept --open flag without error", async () => {
+    const port = await findFreePort();
+
+    // Start server with --open flag
+    // Note: In CI/test environment, the browser won't actually open,
+    // but the command should not error
+    const server = spawnSpotlight(["server", "-p", port.toString(), "--open"]);
+    activeProcesses.push(server);
+
+    await waitForSidecarReady(port, 10000);
+
+    // Server should be running despite --open flag (even if browser doesn't open)
+    const stderr = server.stderr.join("");
+    expect(stderr).toMatch(/listening/i);
+    // Should not have any errors about unknown flags
+    expect(stderr).not.toMatch(/unknown.*option.*open/i);
+  }, 15000);
+
+  it("should accept -o short flag without error", async () => {
+    const port = await findFreePort();
+
+    // Start server with -o flag
+    const server = spawnSpotlight(["server", "-p", port.toString(), "-o"]);
+    activeProcesses.push(server);
+
+    await waitForSidecarReady(port, 10000);
+
+    // Server should be running
+    const stderr = server.stderr.join("");
+    expect(stderr).toMatch(/listening/i);
+  }, 15000);
+
+  it("should work with combined flags including --open", async () => {
+    const port = await findFreePort();
+
+    // Start server with multiple flags
+    const server = spawnSpotlight(["-p", port.toString(), "-d", "--open"]);
+    activeProcesses.push(server);
+
+    await waitForSidecarReady(port, 10000);
+
+    // Server should be running
+    const stderr = server.stderr.join("");
+    expect(stderr).toMatch(/listening/i);
+  }, 15000);
+});


### PR DESCRIPTION
Add a new `--open` / `-o` CLI flag that automatically opens the Spotlight
web dashboard in the user's default browser when starting the sidecar server.

Implementation:
- Add `openInBrowser` utility using platform-specific commands
  (macOS: open, Windows: cmd /c start, Linux: xdg-open)
- Add `--open` / `-o` boolean flag to CLI argument parsing
- Update help text with new flag documentation
- Implement browser opening in both `server` and `run` commands
- Add E2E tests for the new flag

Closes #1192
