### PR TITLE
fix(ui): Correct flamechart tree ordering to build from root to leaf

### DIFF
--- a/.changeset/fix-flamechart-tree-ordering.md
+++ b/.changeset/fix-flamechart-tree-ordering.md
@@ -1,0 +1,6 @@
+---
+"@spotlightjs/spotlight": patch
+---
+
+Fixed flamechart tree building to iterate from root to leaf frames, resolving fragmented visualization
+

--- a/packages/spotlight/src/ui/telemetry/utils/profileTree.ts
+++ b/packages/spotlight/src/ui/telemetry/utils/profileTree.ts
@@ -108,7 +108,7 @@ function buildTree(profile: SentryProfileWithTraceMeta, options: FlamegraphUtilO
     let currentNode: TreeNodeWithMap = root;
     root.sampleCount++;
     for (let depth = 0; depth < stack.length; depth++) {
-      const frameId = stack[stack.length - 1 - depth];
+      const frameId = stack[depth];
       const frame = frames[frameId];
       if (!frame) continue;
       if (!currentNode.childrenMap) {


### PR DESCRIPTION
The profile tree was being built with a double-reversal bug:
1. profileProcessor.ts reverses stacks (root at index 0)
2. profileTree.ts iterated in reverse again, starting from leaf

Changed tree building to iterate forward through the already-reversed
stacks, correctly building from root frames to leaf frames.

Fixes #1100

<img width="2880" height="1744" alt="image" src="https://github.com/user-attachments/assets/c3015749-f0c0-4bf9-9ced-ac9f5ccc5601" />

