### PR TITLE
Qs security vulnerability fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "tmp": ">=0.2.4",
     "js-yaml": ">=4.1.1",
     "body-parser": ">=2.2.1",
-    "mdast-util-to-hast": ">=13.2.1"
+    "mdast-util-to-hast": ">=13.2.1",
+    "qs": ">=6.14.1"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,7 @@ overrides:
   js-yaml: '>=4.1.1'
   body-parser: '>=2.2.1'
   mdast-util-to-hast: '>=13.2.1'
+  qs: '>=6.14.1'
   vite@>=6.0.0 <6.3.6: '>=6.3.6'
 
 importers:
@@ -6297,8 +6298,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.14.0:
-    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+  qs@6.14.1:
+    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.10:
@@ -11377,7 +11378,7 @@ snapshots:
       http-errors: 2.0.0
       iconv-lite: 0.7.1
       on-finished: 2.4.1
-      qs: 6.14.0
+      qs: 6.14.1
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -12437,7 +12438,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.0
+      qs: 6.14.1
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.0
@@ -14597,7 +14598,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.14.0:
+  qs@6.14.1:
     dependencies:
       side-channel: 1.1.0
 


### PR DESCRIPTION
Fix: Upgrade `qs` to 6.14.1 to address DoS vulnerability

This PR addresses a security vulnerability in the `qs` package where its `arrayLimit` bypass in bracket notation (`a[]=1&a[]=2`) allows Denial-of-Service (DoS) via memory exhaustion.

The `qs` package was a transitive dependency at version `6.14.0`, which is vulnerable. Dependabot could not automatically update it to the patched version `6.14.1`.

To mitigate this, `qs` has been explicitly added to the `resolutions` section in `package.json` (and `overrides` in `pnpm-lock.yaml`), forcing the installation of version `6.14.1` or higher.

**Verification:**
- `qs` updated from 6.14.0 to 6.14.1.
- Linting and build processes completed successfully.

<!--
Tick these boxes if they're applicable to your PR.
- Changesets are only required for PRs to Spotlight library packages (e.g. @spotlightjs/overlay). Not for the website/docs or demo app contributions.
- Typo correction or small bugfix PRs don't require an issue. If you're making a bigger change, please open an issue first.
-->

Before opening this PR:

- [ ] I added a [Changeset Entry](https://spotlightjs.com/contribute/changesets/) with `pnpm changeset:add`
- [ ] I referenced issues that this PR addresses

---
<a href="https://cursor.com/background-agent?bcId=bc-229a24b1-d070-4f0a-8e75-5ad147de75d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-229a24b1-d070-4f0a-8e75-5ad147de75d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

