### PR TITLE
fix: shiki theme in light mode

### DIFF
--- a/packages/website/astro.config.mjs
+++ b/packages/website/astro.config.mjs
@@ -140,7 +140,7 @@ export default defineConfig({
         },
       ],
       expressiveCode: {
-        themes: ["starlight-dark", "starlight-light"],
+        themes: ["starlight-dark"],
         useStarlightUiThemeColors: true,
       },
       editLink: {


### PR DESCRIPTION
Removed the light mode theme, so that dark mode theme is used for all color modes