### PR TITLE
docs: document turbo.json SENTRY_SPOTLIGHT env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,33 @@ Spotlight uses Sentry SDKs to capture telemetry data and sends it to the Sidecar
 - [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
 - [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
 
+## Turborepo Setup
+
+When using Spotlight in a [Turborepo](https://turbo.build/) monorepo, declare `SENTRY_SPOTLIGHT` as a global environment variable in `turbo.json` so it's available to all packages during dev and build:
+
+```json
+{
+  "globalEnv": ["SENTRY_SPOTLIGHT"]
+}
+```
+
+Alternatively, scope the variable to specific pipeline tasks:
+
+```json
+{
+  "pipeline": {
+    "dev": {
+      "env": ["SENTRY_SPOTLIGHT"]
+    },
+    "build": {
+      "env": ["SENTRY_SPOTLIGHT"]
+    }
+  }
+}
+```
+
+Without this, `SENTRY_SPOTLIGHT` may not be forwarded to packages that consume the Sentry SDK, and Spotlight won't receive telemetry from those packages.
+
 ## Resources
 
 - [Contribute](https://spotlightjs.com/docs/contribute/)

--- a/README.md
+++ b/README.md
@@ -43,33 +43,6 @@ Spotlight uses Sentry SDKs to capture telemetry data and sends it to the Sidecar
 - [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
 - [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
 
-## Turborepo Setup
-
-When using Spotlight in a [Turborepo](https://turbo.build/) monorepo, declare `SENTRY_SPOTLIGHT` as a global environment variable in `turbo.json` so it's available to all packages during dev and build:
-
-```json
-{
-  "globalEnv": ["SENTRY_SPOTLIGHT"]
-}
-```
-
-Alternatively, scope the variable to specific pipeline tasks:
-
-```json
-{
-  "pipeline": {
-    "dev": {
-      "env": ["SENTRY_SPOTLIGHT"]
-    },
-    "build": {
-      "env": ["SENTRY_SPOTLIGHT"]
-    }
-  }
-}
-```
-
-Without this, `SENTRY_SPOTLIGHT` may not be forwarded to packages that consume the Sentry SDK, and Spotlight won't receive telemetry from those packages.
-
 ## Resources
 
 - [Contribute](https://spotlightjs.com/docs/contribute/)

--- a/packages/website/src/content/docs/docs/quickstart/turborepo.mdx
+++ b/packages/website/src/content/docs/docs/quickstart/turborepo.mdx
@@ -1,0 +1,61 @@
+---
+title: Turborepo
+description: Configure Spotlight to work across packages in a Turborepo monorepo
+---
+
+When using Spotlight in a [Turborepo](https://turbo.build/) monorepo, the `SENTRY_SPOTLIGHT` environment variable must be declared in `turbo.json` for it to be available to all packages. Without this, Turborepo may not forward the variable to packages that consume the Sentry SDK, and Spotlight won't receive telemetry from those packages.
+
+:::note[Already set up Spotlight?]
+This guide assumes you've already installed the Sentry SDK and Spotlight in your project. If not, see the [Getting Started](/docs/getting-started/) guide first.
+:::
+
+## Option 1: Global Environment Variable
+
+The simplest approach is to declare `SENTRY_SPOTLIGHT` as a global environment variable. This makes it available to all tasks in every package:
+
+```json
+// turbo.json
+{
+  "globalEnv": ["SENTRY_SPOTLIGHT"]
+}
+```
+
+## Option 2: Scope to Specific Tasks
+
+If you prefer more granular control, you can scope the variable to specific tasks using the `tasks` configuration:
+
+```json
+// turbo.json
+{
+  "tasks": {
+    "dev": {
+      "env": ["SENTRY_SPOTLIGHT"]
+    },
+    "build": {
+      "env": ["SENTRY_SPOTLIGHT"]
+    }
+  }
+}
+```
+
+This ensures `SENTRY_SPOTLIGHT` is only forwarded to the `dev` and `build` tasks, keeping other tasks unaffected.
+
+## Verify It Works
+
+1. Set the environment variable in your `.env` file or shell:
+   ```bash
+   SENTRY_SPOTLIGHT=1
+   ```
+
+2. Run your Turborepo dev task:
+   ```bash
+   turbo dev
+   ```
+
+3. Open the [Spotlight UI](http://localhost:8969) and confirm that telemetry from all packages appears.
+
+## Next Steps
+
+- [Getting Started](/docs/getting-started/) - Initial Spotlight setup
+- [CLI](/docs/cli/) - Run apps with automatic instrumentation and stream events
+- [Sidecar](/docs/sidecar/) - Learn about the local proxy server that powers Spotlight


### PR DESCRIPTION
## Summary
Fixes #868 — adds a Turborepo Setup section to the README documenting how to configure the `SENTRY_SPOTLIGHT` environment variable in `turbo.json`.

## Problem
When using Spotlight in a Turborepo monorepo, `SENTRY_SPOTLIGHT` must be declared in `turbo.json` for it to be available across all packages. Without this configuration, the environment variable may not be forwarded to packages consuming the Sentry SDK, and Spotlight won't receive telemetry from those packages.

## Change
Added a "Turborepo Setup" section to `README.md` with:
- Global env variable declaration (`globalEnv`)
- Scoped pipeline configuration (`pipeline.dev.env`, `pipeline.build.env`)
- Brief explanation of why this is needed

## Type of Change
- [x] Documentation