### PR TITLE
security(deps): resolve 5 open dependabot alerts (shell-quote, hono)

### DIFF
--- a/.lore.md
+++ b/.lore.md
@@ -1,0 +1,13 @@
+<!-- Managed by lore (https://github.com/BYK/loreai) — manual edits are imported on next session. -->
+
+## Long-term Knowledge
+
+### Decision
+
+<!-- lore:019e2add-e248-7c69-81d6-55de39182966 -->
+* **Migrated to Content Layer API**: migrated to Content Layer API,
+
+### Gotcha
+
+<!-- lore:019e2b7e-99e1-7402-8c4f-9699919d7e69 -->
+* **plist override breaks electron-builder osx-sign**: Forcing \`plist>=3.1.1\` via pnpm overrides bumps it to v5.x, which breaks \`@electron/osx-sign@1.0.5\` (used by \`electron-builder@24.13.3\`) due to incompatible CJS \`require()\` and new \`exports\` map. Fix: remove the \`plist\` override and instead override \`@xmldom/xmldom\` directly to \`>=0.8.13\` (first patched 0.8.x version). This keeps \`plist@3.1.0\` for osx-sign compatibility while eliminating the \`@xmldom/xmldom\` vulnerability.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,2 +1,5 @@
-<!-- This section is maintained by the coding agent via lore (https://github.com/BYK/opencode-lore) -->
+<!-- This section is maintained by the coding agent via lore (https://github.com/BYK/loreai) -->
+## Long-term Knowledge
+
+For long-term knowledge entries managed by [lore](https://github.com/BYK/loreai) (gotchas, patterns, decisions, architecture), see [`.lore.md`](.lore.md) in the project root.
 <!-- End lore-managed section -->

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
       "svelte": ">=5.55.7",
       "ws": ">=8.20.1",
       "react-router@>=6.7.0 <7.0.0": ">=6.30.4",
-      "react-router-dom@>=6.0.0 <7.0.0": ">=6.30.4"
+      "react-router-dom@>=6.0.0 <7.0.0": ">=6.30.4",
+      "shell-quote": ">=1.8.4"
     }
   },
   "simple-git-hooks": {

--- a/packages/spotlight/package.json
+++ b/packages/spotlight/package.json
@@ -32,9 +32,7 @@
     "test:e2e:electron": "playwright test tests/electron.test.ts",
     "sample": "node ./_fixtures/send_to_sidecar.cjs"
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "bin": {
     "spotlight": "./dist/run.js"
   },
@@ -62,8 +60,8 @@
     "chalk": "^5.6.2",
     "eventsource": "^4.0.0",
     "fast-fuzzy": "^1.12.0",
-    "hono": "^4.12.18",
-    "launch-editor": "^2.9.1",
+    "hono": "^4.12.21",
+    "launch-editor": "^2.14.1",
     "logfmt": "^1.4.0",
     "mcp-proxy": "^5.6.0",
     "semver": "^7.7.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,7 @@ overrides:
   ws: '>=8.20.1'
   react-router@>=6.7.0 <7.0.0: '>=6.30.4'
   react-router-dom@>=6.0.0 <7.0.0: '>=6.30.4'
+  shell-quote: '>=1.8.4'
 
 importers:
 
@@ -113,10 +114,10 @@ importers:
     dependencies:
       '@hono/mcp':
         specifier: ^0.2.2
-        version: 0.2.2(@modelcontextprotocol/sdk@1.27.1(zod@4.1.13))(hono-rate-limiter@0.4.2(hono@4.12.18))(hono@4.12.18)(zod@4.1.13)
+        version: 0.2.2(@modelcontextprotocol/sdk@1.27.1(zod@4.1.13))(hono-rate-limiter@0.4.2(hono@4.12.25))(hono@4.12.25)(zod@4.1.13)
       '@hono/node-server':
         specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.18)
+        version: 1.19.14(hono@4.12.25)
       '@jridgewell/trace-mapping':
         specifier: ^0.3.25
         version: 0.3.31
@@ -142,11 +143,11 @@ importers:
         specifier: ^1.12.0
         version: 1.12.0
       hono:
-        specifier: ^4.12.18
-        version: 4.12.18
+        specifier: ^4.12.21
+        version: 4.12.25
       launch-editor:
-        specifier: ^2.9.1
-        version: 2.10.0
+        specifier: ^2.14.1
+        version: 2.14.1
       logfmt:
         specifier: ^1.4.0
         version: 1.4.0
@@ -4579,8 +4580,8 @@ packages:
     peerDependencies:
       hono: ^4.1.1
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@4.1.0:
@@ -4932,8 +4933,8 @@ packages:
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
 
-  launch-editor@2.10.0:
-    resolution: {integrity: sha512-D7dBRJo/qcGX9xlvt/6wUYzQxjh5G1RvZPgPv8vi4KRU99DVQL/oW7tnVOCCTm2HGeo3C5HvGE5Yrh6UBoZ0vA==}
+  launch-editor@2.14.1:
+    resolution: {integrity: sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==}
 
   lazy-val@1.0.5:
     resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
@@ -6330,8 +6331,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@3.13.0:
@@ -8114,17 +8115,17 @@ snapshots:
 
   '@fontsource/raleway@5.2.5': {}
 
-  '@hono/mcp@0.2.2(@modelcontextprotocol/sdk@1.27.1(zod@4.1.13))(hono-rate-limiter@0.4.2(hono@4.12.18))(hono@4.12.18)(zod@4.1.13)':
+  '@hono/mcp@0.2.2(@modelcontextprotocol/sdk@1.27.1(zod@4.1.13))(hono-rate-limiter@0.4.2(hono@4.12.25))(hono@4.12.25)(zod@4.1.13)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.27.1(zod@4.1.13)
-      hono: 4.12.18
-      hono-rate-limiter: 0.4.2(hono@4.12.18)
+      hono: 4.12.25
+      hono-rate-limiter: 0.4.2(hono@4.12.25)
       pkce-challenge: 5.0.0
       zod: 4.1.13
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
 
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
@@ -8451,7 +8452,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.27.1(zod@4.1.13)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.18.0
       ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
@@ -8461,7 +8462,7 @@ snapshots:
       eventsource-parser: 3.0.6
       express: 5.2.1
       express-rate-limit: 8.3.1(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.25
       jose: 6.1.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10885,7 +10886,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       rxjs: 7.8.2
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       supports-color: 8.1.1
       tree-kill: 1.2.2
       yargs: 17.7.2
@@ -12205,11 +12206,11 @@ snapshots:
     dependencies:
       react-is: 16.13.1
 
-  hono-rate-limiter@0.4.2(hono@4.12.18):
+  hono-rate-limiter@0.4.2(hono@4.12.25):
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.25
 
-  hono@4.12.18: {}
+  hono@4.12.25: {}
 
   hosted-git-info@4.1.0:
     dependencies:
@@ -12505,10 +12506,10 @@ snapshots:
 
   kolorist@1.8.0: {}
 
-  launch-editor@2.10.0:
+  launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   lazy-val@1.0.5: {}
 
@@ -14270,7 +14271,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@3.13.0:
     dependencies:


### PR DESCRIPTION
## Summary

Resolves all **5 open Dependabot alerts** (1 critical, 4 medium). No security advisories were open.

| Package | Severity | Alert(s) | Fix |
|---------|----------|----------|-----|
| `shell-quote` | Critical | #278 | pnpm override `>=1.8.4` + bump `launch-editor` to `^2.14.1` |
| `hono` | Medium | #274, #275, #276, #277 | bump constraint to `^4.12.21` (resolves to `4.12.25`) |

## Details

### shell-quote (GHSA-w7jw-789q-3m8p / CVE-2026-9277)
`quote()` does not escape newlines in object `.op` values, enabling shell command injection. It is a transitive dependency pulled in by:
- `launch-editor` (prod) — bumped to `^2.14.1`, which already depends on `shell-quote@^1.8.4`
- `concurrently@9.2.1` (dev) — **hard-pins** `shell-quote@1.8.3`, so a `pnpm.overrides` entry (`>=1.8.4`) is required to force the patched version without a major bump of `concurrently`.

### hono (#274–#277)
Direct dependency of `@spotlightjs/spotlight`. Bumping `^4.12.18` → `^4.12.21` resolves to `4.12.25`, covering:
- JWT middleware accepting any Authorization scheme (not only Bearer)
- Cookie helper `Set-Cookie` injection via `sameSite`/`priority`
- IP Restriction bypass of static deny rules for non-canonical IPv6
- `app.mount()` incorrect routing for percent-encoded paths

## Verification
- `pnpm install` succeeds; lockfile diff is scoped to the three packages
- `pnpm why shell-quote -r` → `1.8.4` everywhere
- `pnpm why hono -r` → `4.12.25` everywhere
- `pnpm run build` passes locally