### PR TITLE
fix(mcp): handle ISO 8601 string timestamps from non-JS SDKs

### DIFF
--- a/packages/spotlight/src/server/formatters/__tests__/utils.test.ts
+++ b/packages/spotlight/src/server/formatters/__tests__/utils.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { formatTimestamp, getDuration } from "../utils.ts";
+
+describe("formatTimestamp", () => {
+  it("formats numeric Unix seconds (JavaScript SDK)", () => {
+    expect(formatTimestamp(1700660724.334)).toBe("2023-11-22T13:45:24.334Z");
+  });
+
+  it("formats ISO 8601 strings (Python SDK)", () => {
+    expect(formatTimestamp("2023-11-22T16:23:50.406684Z")).toBe("2023-11-22T16:23:50.406Z");
+  });
+
+  it("formats numeric strings as Unix seconds", () => {
+    expect(formatTimestamp("1700660724.334")).toBe("2023-11-22T13:45:24.334Z");
+  });
+
+  it("falls back to epoch for missing timestamps", () => {
+    expect(formatTimestamp(undefined)).toBe("1970-01-01T00:00:00.000Z");
+    expect(formatTimestamp("")).toBe("1970-01-01T00:00:00.000Z");
+  });
+
+  it("falls back to epoch for unparseable strings instead of throwing", () => {
+    expect(() => formatTimestamp("not-a-date")).not.toThrow();
+    expect(formatTimestamp("not-a-date")).toBe("1970-01-01T00:00:00.000Z");
+  });
+});
+
+describe("getDuration", () => {
+  it("computes duration from numeric Unix seconds", () => {
+    expect(getDuration(1700660724.5, 1700660724)).toBe(500);
+  });
+
+  it("computes duration from numeric strings", () => {
+    expect(getDuration("1700660724.5", "1700660724")).toBe(500);
+  });
+
+  it("computes duration from ISO 8601 strings (Python SDK)", () => {
+    expect(getDuration("2023-11-22T16:23:50.406684Z", "2023-11-22T16:23:49.525798Z")).toBe(881);
+  });
+
+  it("returns undefined when a timestamp is missing", () => {
+    expect(getDuration(undefined, 1700660724)).toBeUndefined();
+    expect(getDuration(1700660724, undefined)).toBeUndefined();
+  });
+
+  it("returns undefined for unparseable timestamps", () => {
+    expect(getDuration("not-a-date", "also-bad")).toBeUndefined();
+  });
+});

--- a/packages/spotlight/src/server/formatters/md/__tests__/errors.test.ts
+++ b/packages/spotlight/src/server/formatters/md/__tests__/errors.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { processErrorEvent } from "../errors.ts";
+
+// Regression tests for Python (and other) SDKs that emit ISO 8601 string
+// timestamps. formatTimestamp used to multiply these by 1000, producing NaN,
+// which threw "Invalid time value" from processErrorEvent. In search_errors
+// that throw was swallowed per-envelope, so Python errors silently vanished.
+describe("processErrorEvent", () => {
+  const baseEvent = {
+    event_id: "abc123",
+    exception: { values: [{ type: "ValueError", value: "boom" }] },
+    message: "boom",
+  };
+
+  it("handles ISO 8601 string timestamps (Python SDK) without throwing", () => {
+    expect(() => processErrorEvent({ ...baseEvent, timestamp: "2023-11-22T16:23:50.406684Z" })).not.toThrow();
+
+    const result = processErrorEvent({ ...baseEvent, timestamp: "2023-11-22T16:23:50.406684Z" });
+    expect(result.dateCreated).toBe("2023-11-22T16:23:50.406Z");
+  });
+
+  it("handles numeric Unix-seconds timestamps (JavaScript SDK)", () => {
+    const result = processErrorEvent({ ...baseEvent, timestamp: 1700660724.334 });
+    expect(result.dateCreated).toBe("2023-11-22T13:45:24.334Z");
+  });
+});

--- a/packages/spotlight/src/server/formatters/utils.ts
+++ b/packages/spotlight/src/server/formatters/utils.ts
@@ -1,28 +1,80 @@
 /**
- * Format a Sentry timestamp (in seconds) to ISO string.
- * Sentry timestamps are Unix timestamps in seconds, so we multiply by 1000 to convert to milliseconds.
- * Falls back to epoch (1970-01-01T00:00:00.000Z) if timestamp is missing/invalid.
+ * Format a Sentry timestamp to an ISO string.
+ *
+ * Sentry SDKs are inconsistent about the timestamp format they emit:
+ * - JavaScript SDKs send a numeric Unix timestamp in seconds (e.g. `1700660724.334`).
+ * - Python (and some other) SDKs send an ISO 8601 string (e.g. `"2023-11-22T16:23:50.406684Z"`).
+ *
+ * Numeric values are treated as Unix seconds and converted to milliseconds. String values that
+ * look numeric are handled the same way, while other strings are parsed as dates directly.
+ * Falls back to epoch (1970-01-01T00:00:00.000Z) if the timestamp is missing or invalid, so that
+ * downstream `.toISOString()` never throws a `RangeError: Invalid time value`.
  */
-export function formatTimestamp(timestamp?: number): string {
-  const date = timestamp ? new Date(timestamp * 1000) : new Date(0);
-  return date.toISOString();
+export function formatTimestamp(timestamp?: number | string): string {
+  const date = parseTimestamp(timestamp);
+  return (Number.isNaN(date.getTime()) ? new Date(0) : date).toISOString();
+}
+
+/**
+ * Parse a Sentry timestamp (numeric Unix seconds or ISO 8601 string) into a Date.
+ * Returns an invalid Date (NaN) if the value cannot be parsed.
+ */
+function parseTimestamp(timestamp?: number | string): Date {
+  if (timestamp === undefined || timestamp === null || timestamp === "") {
+    return new Date(0);
+  }
+
+  if (typeof timestamp === "number") {
+    return new Date(timestamp * 1000);
+  }
+
+  // Numeric string, e.g. "1700660724.334" -> treat as Unix seconds.
+  const numeric = Number(timestamp);
+  if (!Number.isNaN(numeric)) {
+    return new Date(numeric * 1000);
+  }
+
+  // Otherwise assume an ISO 8601 (or other Date-parseable) string.
+  return new Date(timestamp);
 }
 
 /**
  * Get the duration in milliseconds between two Sentry timestamps.
- * Accepts timestamps in seconds (as numbers or strings).
+ * Accepts timestamps as Unix seconds (numbers or numeric strings) or ISO 8601 strings.
  * Returns undefined if either timestamp is missing or invalid.
  */
 
 export function getDuration(endTimestamp?: number | string, startTimestamp?: number | string): number | undefined {
-  const end = typeof endTimestamp === "string" ? Number.parseFloat(endTimestamp) : endTimestamp;
-  const start = typeof startTimestamp === "string" ? Number.parseFloat(startTimestamp) : startTimestamp;
+  const end = toEpochSeconds(endTimestamp);
+  const start = toEpochSeconds(startTimestamp);
 
-  if (typeof end === "number" && typeof start === "number" && !Number.isNaN(end) && !Number.isNaN(start)) {
+  if (end !== undefined && start !== undefined) {
     return Math.round((end - start) * 1000);
   }
 
   return undefined;
+}
+
+/**
+ * Convert a Sentry timestamp (Unix seconds, numeric string, or ISO 8601 string) to Unix seconds.
+ * Returns undefined if the value is missing or cannot be parsed.
+ */
+function toEpochSeconds(timestamp?: number | string): number | undefined {
+  if (timestamp === undefined || timestamp === null || timestamp === "") {
+    return undefined;
+  }
+
+  if (typeof timestamp === "number") {
+    return Number.isNaN(timestamp) ? undefined : timestamp;
+  }
+
+  const numeric = Number(timestamp);
+  if (!Number.isNaN(numeric)) {
+    return numeric;
+  }
+
+  const parsed = new Date(timestamp).getTime();
+  return Number.isNaN(parsed) ? undefined : parsed / 1000;
 }
 
 /**

--- a/packages/spotlight/tests/e2e/cli/mcp.e2e.test.ts
+++ b/packages/spotlight/tests/e2e/cli/mcp.e2e.test.ts
@@ -262,6 +262,43 @@ describe("spotlight mcp e2e tests", () => {
     // This test verifies the search functionality works, which is the first step
   }, 15000);
 
+  // Regression test: Python (and other) SDKs send ISO 8601 string timestamps
+  // (e.g. "2023-11-22T16:23:50.406684Z") rather than the numeric Unix seconds
+  // used by the JavaScript SDK. formatTimestamp previously multiplied these
+  // strings by 1000, producing NaN and throwing "Invalid time value" from
+  // search_traces (and silently swallowing the error in search_errors).
+  it("should handle Python ISO-8601 string timestamps via MCP SDK", async () => {
+    const port = await findFreePort();
+
+    const server = spawnSpotlight(["server", "-p", port.toString()]);
+    activeProcesses.push(server);
+    await waitForSidecarReady(port, 10000);
+
+    // envelope_python.txt carries ISO-string timestamps on its transactions
+    const pythonPath = getFixturePath("envelope_python.txt");
+    await sendEnvelope(port, pythonPath);
+
+    await new Promise(resolve => setTimeout(resolve, 500));
+
+    const client = await createMCPClient(port);
+
+    // search_traces must not throw "Invalid time value" and must return a trace summary
+    const tracesResult = await client.callTool({
+      name: "search_traces",
+      arguments: { filters: { timeWindow: 3600 } },
+    });
+
+    expect(tracesResult.isError ?? false).toBe(false);
+    const traceText = (tracesResult.content as Array<{ type: string; text?: string }>)
+      .filter(item => item.type === "text" && item.text)
+      .map(item => item.text as string)
+      .join("\n");
+    expect(traceText).not.toContain("Invalid time value");
+    expect(traceText).toContain("Local Traces");
+    // The formatted timestamp must be a valid (non-epoch) ISO date derived from the ISO input
+    expect(traceText).toMatch(/2023-11-22T\d{2}:\d{2}:\d{2}/);
+  }, 15000);
+
   it("should handle errors gracefully via MCP SDK", async () => {
     const port = await findFreePort();
 


### PR DESCRIPTION
## Problem

Reported by a user running Spotlight with the **Python SDK** and the MCP server in Cursor: events show up in the UI, but MCP returns nothing — `search_errors` returns no errors, and `search_traces` throws `Invalid time value`.

## Root cause

The MCP formatters assumed Sentry timestamps are always **numeric Unix seconds** (what the JavaScript SDK sends, e.g. `1700660724.334`). The **Python SDK sends ISO 8601 strings** (e.g. `"2023-11-22T16:23:50.406684Z"`).

`formatTimestamp` in `packages/spotlight/src/server/formatters/utils.ts` did:

```ts
const date = timestamp ? new Date(timestamp * 1000) : new Date(0);
return date.toISOString();
```

An ISO string × `1000` → `NaN` → `new Date(NaN).toISOString()` → `RangeError: Invalid time value`.

This surfaced two ways:

| Tool | Symptom | Why |
| --- | --- | --- |
| `search_traces` | `Invalid time value` | throw in `formatTraceSummary` (`md/traces.ts:421`) is **uncaught** and propagates out of the tool |
| `search_errors` | returns nothing | same throw in `processErrorEvent` (`md/errors.ts:80`) is **swallowed** per-envelope by `captureException` (`mcp/mcp.ts:134-136`), so content is empty → `NO_ERRORS_CONTENT` |

The UI parses timestamps independently, which is why events appear there but not via MCP.

## Fix

`formatTimestamp` and `getDuration` now accept **numeric Unix seconds, numeric strings, and ISO 8601 strings**, and fall back safely (epoch / `undefined`) instead of throwing on invalid input.

## Reproduction

Verified end-to-end against the real Python SDK (`sentry-sdk 2.66.0`) and the checked-in `envelope_python.txt` fixture, driving the actual `spotlight mcp` server via the MCP SDK client:

- **Before:** `search_errors` → "No errors detected"; `search_traces` → `Invalid time value`
- **After:** `search_errors` → returns the `ValueError`; `search_traces` → `**5eddc43c** | repro-transaction | 84ms | 2 spans | 1 errors | 2026-07-21T09:02:14.794Z`
- JavaScript SDK (`envelope_javascript.txt`) continues to work (control).

## Tests

- Unit: `formatTimestamp` / `getDuration` cover numeric, numeric-string, ISO-string, missing, and unparseable inputs.
- Unit: `processErrorEvent` no longer throws on ISO-string timestamps (guards the swallowed `search_errors` path).
- E2E: new MCP regression test sends `envelope_python.txt` and asserts `search_traces` does not error and returns a valid (non-epoch) timestamp.

All 9 MCP e2e tests and the formatter unit suites pass. (One unrelated pre-existing UI failure in `TelemetryTabs.test.tsx` exists on `main` independent of this change.)