### PR TITLE
ci: Reference renamed coverage action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,7 +213,7 @@ jobs:
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
-        uses: getsentry/codecov-action@main
+        uses: getsentry/coverage-action@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           post-pr-comment: true


### PR DESCRIPTION
The test-results workflow now references the canonical `getsentry/coverage-action` repository. The existing `@main` update policy and action inputs are unchanged.
